### PR TITLE
Remove dependancy on ActiveSupport

### DIFF
--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Fastly NSQ Adapter'
   gem.description   = "Helper classes for Fastly's NSQ Services"
   gem.license       = 'MIT'
-  gem.authors       = ["Tommy O'Neill, Adarsh Pandit"]
+  gem.authors       = ["Tommy O'Neil", 'Adarsh Pandit']
   gem.email         = 'tommy@fastly.com'
   gem.homepage      = 'https://github.com/fastly/fastly-nsq'
 
@@ -30,6 +30,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec-mocks', '~> 3.4'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
 
-  gem.add_dependency 'activesupport', '~> 4.2', '>= 4.2.5.1'
   gem.add_dependency 'nsq-ruby', '~> 1.5.0', '>= 1.5.0'
 end

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -1,8 +1,11 @@
-require 'active_support/core_ext/module/attribute_accessors'
-require 'active_support/core_ext/module/introspection'
-
 module FakeMessageQueue
-  cattr_accessor :queue
+  def self.queue
+    @@queue
+  end
+
+  def self.queue=(message)
+    @@queue = message
+  end
 
   def self.reset!
     self.queue = []
@@ -20,7 +23,7 @@ module FakeMessageQueue
     private
 
     def queue
-      self.class.parent.queue
+      FakeMessageQueue.queue
     end
   end
 
@@ -39,7 +42,7 @@ module FakeMessageQueue
     private
 
     def queue
-      self.class.parent.queue
+      FakeMessageQueue.queue
     end
   end
 

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
# Reason for Change
- Our dependency on `ActiveSupport` collides with some older Rails apps.
# Changes
- Remove the dependency by just writing our own `cattr_accessor`.
- Bump the version.
