### PR TITLE
Use a more canonical way to require files

### DIFF
--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.email         = 'tommy@fastly.com'
   gem.homepage      = 'https://github.com/fastly/fastly-nsq'
 
-  gem.files         = ['lib/fastly_nsq']
+  gem.files         = `git ls-files`.split("\n")
 
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|features)/})


### PR DESCRIPTION
# Reason for Change
- When using the gem as a git remote in bundler (either with a branch or without) in William, all files were `require`d.
- Now it’s up on rubygems.org, it does not require any of the files.
# Changes
- Use the prescribed way to require all files in the `/lib` directory. While this seems aggressive to me, I guess it's standard.
