### PR TITLE
Initialize the fake queue with an empty array

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ start by using the fake queue:
 FAKE_QUEUE=true
 ```
 
+Also be sure call
+`FakeMessageQueue.reset!`
+before each test in your app to ensure
+there are no leftover messages.
+
 Also note that during gem tests,
 we are aliasing `MessageProcessor` to `SampleMessageProcessor`.
 You can also refer to the latter

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -1,4 +1,6 @@
 module FakeMessageQueue
+  @@queue = []
+
   def self.queue
     @@queue
   end

--- a/test/lib/fastly_nsq/fake_message_queue_test.rb
+++ b/test/lib/fastly_nsq/fake_message_queue_test.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 
 describe FakeMessageQueue do
+  describe '@@queue' do
+    it 'is initalized as an empty array' do
+      assert_equal [], FakeMessageQueue.queue
+    end
+  end
+
   describe '.reset!' do
     it 'resets the fake message queue' do
       FakeMessageQueue.queue = ['hello']
@@ -14,6 +20,10 @@ describe FakeMessageQueue do
 end
 
 describe FakeMessageQueue::Producer do
+  after do
+    FakeMessageQueue.reset!
+  end
+
   describe '#write' do
     it 'adds a new message to the queue' do
       topic = 'death_star'
@@ -30,6 +40,10 @@ describe FakeMessageQueue::Producer do
 end
 
 describe FakeMessageQueue::Message do
+  after do
+    FakeMessageQueue.reset!
+  end
+
   describe '#body' do
     it 'returns the body of the message' do
       topic = 'death_star'
@@ -49,6 +63,10 @@ describe FakeMessageQueue::Message do
 end
 
 describe FakeMessageQueue::Consumer do
+  after do
+    FakeMessageQueue.reset!
+  end
+
   describe '#size' do
     it 'tells you how many messages are in the queue' do
       FakeMessageQueue.queue = ['hello']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,6 @@ MessageProcessor = SampleMessageProcessor
 
 MiniTest::Spec.before do
   load_sample_environment_variables
-  FakeMessageQueue.reset!
 end
 
 def load_sample_environment_variables


### PR DESCRIPTION
# Reason for Change
- When installing the gem on another application, I noticed some failures related to the lack of calling `FakeMessageQueue.reset!` before each test.
- This is due to not initializing the class queue variable at the outset.
# Changes
- Initialize the queue to `[]` to start, removing the requirement to `FakeMessageQueue.reset!` to get started.
- Change the tests to only call the reset when necessary, not every time.
- Update the documentation.
