### PR TITLE
Fix test errors

### DIFF
--- a/test/lib/fastly_nsq/message_queue/strategy_test.rb
+++ b/test/lib/fastly_nsq/message_queue/strategy_test.rb
@@ -9,7 +9,7 @@ describe Strategy do
 
           strategy = Strategy.for_queue
 
-          assert equal FakeMessageQueue, strategy
+          assert_equal FakeMessageQueue, strategy
         end
       end
     end
@@ -21,7 +21,7 @@ describe Strategy do
 
           strategy = Strategy.for_queue
 
-          assert equal Nsq, strategy
+          assert_equal Nsq, strategy
         end
       end
     end


### PR DESCRIPTION
# Reason for Change
- I noticed one test file didn't have the suffix `_test`.
- This means it would not have been run since MiniTest matches on that suffix.
# Changes
- Fix the filename to append `_test`.
- Fix the errors exposed once the test was actually run.
