### PR TITLE
Terminate producer and consumer connections

### DIFF
--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -8,7 +8,11 @@ module MessageQueue
     end
 
     def connection
-      consumer.new(params)
+      @connection ||= consumer.new(params)
+    end
+
+    def terminate
+      @connection.terminate
     end
 
     private

--- a/lib/fastly_nsq/message_queue/listener.rb
+++ b/lib/fastly_nsq/message_queue/listener.rb
@@ -6,22 +6,45 @@ module MessageQueue
     end
 
     def go
+      Signal.trap('INT') do
+        shutdown
+      end
+
+      Signal.trap('TERM') do
+        shutdown
+      end
+
       loop do
-        process_next_message
+        process_one_message
       end
     end
 
     def process_next_message
-      message = consumer.pop
-      MessageProcessor.new(message).go
+      process_one_message
+      consumer.terminate
     end
 
     private
 
+    def process_one_message
+      message = consumer.pop
+      MessageProcessor.new(message.body).go
+      message.finish
+    end
+
     attr_reader :channel, :topic
 
     def consumer
-      MessageQueue::Consumer.new(topic: topic, channel: channel).connection
+      @consumer ||= MessageQueue::Consumer.new(consumer_params).connection
+    end
+
+    def consumer_params
+      { topic: topic, channel: channel }
+    end
+
+    def shutdown
+      consumer.terminate
+      exit
     end
   end
 end

--- a/lib/fastly_nsq/message_queue/producer.rb
+++ b/lib/fastly_nsq/message_queue/producer.rb
@@ -7,7 +7,11 @@ module MessageQueue
     end
 
     def connection
-      producer.new(params)
+      @producer ||= producer.new(params)
+    end
+
+    def terminate
+      @producer.terminate
     end
 
     private

--- a/lib/fastly_nsq/sample_message_processor.rb
+++ b/lib/fastly_nsq/sample_message_processor.rb
@@ -15,20 +15,19 @@ class SampleMessageProcessor
     'heartbeat' => HeartbeatWorker,
   }.freeze
 
-  def initialize(message)
-    @message = message
+  def initialize(message_body)
+    @message_body = message_body
   end
 
   def go
-    process_message
-    message.finish
+    process_message_body
   end
 
   private
 
-  attr_reader :message
+  attr_reader :message_body
 
-  def process_message
+  def process_message_body
     message_processor.perform_async(message_data)
   end
 
@@ -46,9 +45,5 @@ class SampleMessageProcessor
 
   def parsed_message_body
     JSON.parse(message_body)
-  end
-
-  def message_body
-    message.body
   end
 end

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.1.4'
+  VERSION = '0.2.0'
 end

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe MessageQueue::Consumer do
   describe '#connection' do
     describe 'when using the real queue' do
       it 'returns an instance of the queue consumer' do
-        MessageQueue::FALSY_VALUES.each do |no|
-          allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(no)
+        use_real_connection do
           allow(Nsq::Consumer).to receive(:new)
           topic = 'death_star'
           channel = 'star_killer_base'
@@ -21,24 +20,23 @@ RSpec.describe MessageQueue::Consumer do
         end
       end
     end
-  end
 
-  describe 'when using the fake queue' do
-    it 'returns an instance of the queue consumer' do
-      MessageQueue::TRUTHY_VALUES.each do |yes|
-        allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(yes)
-        allow(FakeMessageQueue::Consumer).to receive(:new)
-        topic = 'death_star'
-        channel = 'star_killer_base'
+    describe 'when using the fake queue' do
+      it 'returns an instance of the queue consumer' do
+        use_fake_connection do
+          allow(FakeMessageQueue::Consumer).to receive(:new)
+          topic = 'death_star'
+          channel = 'star_killer_base'
 
-        MessageQueue::Consumer.new(topic: topic, channel: channel).connection
+          MessageQueue::Consumer.new(topic: topic, channel: channel).connection
 
-        expect(FakeMessageQueue::Consumer).to have_received(:new).
-          with(
-            nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
-            topic: topic,
-            channel: channel,
-        ).at_least(:once)
+          expect(FakeMessageQueue::Consumer).to have_received(:new).
+            with(
+              nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
+              topic: topic,
+              channel: channel,
+          ).at_least(:once)
+        end
       end
     end
   end
@@ -52,6 +50,44 @@ RSpec.describe MessageQueue::Consumer do
       consumer = MessageQueue::Consumer.new(topic: topic, channel: channel)
 
       expect{ consumer.connection }.to raise_error(InvalidParameterError)
+    end
+  end
+
+  describe '#terminate' do
+    describe 'when using the real queue' do
+      it 'closes the connection' do
+        use_real_connection do
+          consumer = double('Consumer', connection: nil, terminate: nil)
+          allow(Nsq::Consumer).to receive(:new).and_return(consumer)
+          topic = 'death_star'
+          channel = 'star_killer_base'
+          params = { topic: topic, channel: channel }
+
+          live_consumer = MessageQueue::Consumer.new(params)
+          live_consumer.connection
+          live_consumer.terminate
+
+          expect(consumer).to have_received(:terminate)
+        end
+      end
+    end
+
+    describe 'when using the fake queue' do
+      it 'closes the connection' do
+        use_fake_connection do
+          consumer = double('Consumer', connection: nil, terminate: nil)
+          allow(FakeMessageQueue::Consumer).to receive(:new).and_return(consumer)
+          topic = 'death_star'
+          channel = 'star_killer_base'
+          params = { topic: topic, channel: channel }
+
+          live_consumer = MessageQueue::Consumer.new(params)
+          live_consumer.connection
+          live_consumer.terminate
+
+          expect(consumer).to have_received(:terminate)
+        end
+      end
     end
   end
 end

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -4,11 +4,10 @@ RSpec.describe MessageQueue::Listener do
   describe '#process_next_message' do
     it 'pass the topic and channel to the consumer' do
       allow(SampleMessageProcessor).to receive_message_chain(:new, :go)
-      allow(MessageQueue::Consumer).to receive_message_chain(
-        :new,
-        :connection,
-        :pop,
-      )
+      message = double('Message', finish: nil, body: nil)
+      connection = double('Connection', pop: message, terminate: nil)
+      consumer = double('Consumer', connection: connection)
+      allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
       topic = 'minitest'
       channel = 'northstar'
 
@@ -22,24 +21,58 @@ RSpec.describe MessageQueue::Listener do
     it 'processes the message' do
       process_message = double(go: nil)
       allow(MessageProcessor).to receive(:new).and_return(process_message)
-      message = double
-      allow(MessageQueue::Consumer).to receive_message_chain(
-        :new,
-        :connection,
-        pop: message
-      )
+      message_body = { data: 'value'  }.to_json
+      message = double('Message', finish: nil, body: message_body)
+      connection = double('Connection', pop: message, terminate: nil)
+      consumer = double('Consumer', connection: connection)
+      allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
       topic = 'minitest'
       channel = 'northstar'
 
       MessageQueue::Listener.new(topic: topic, channel: channel).
         process_next_message
 
-      expect(MessageProcessor).to have_received(:new).with(message)
+      expect(MessageProcessor).to have_received(:new).with(message_body)
       expect(process_message).to have_received(:go)
+    end
+
+    it 'finishes the message' do
+      allow(SampleMessageProcessor).to receive_message_chain(:new, :go)
+      message = double('Message', finish: nil, body: nil)
+      connection = double('Connection', pop: message, terminate: nil)
+      consumer = double('Consumer', connection: connection)
+      allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
+      topic = 'minitest'
+      channel = 'northstar'
+
+      MessageQueue::Listener.new(topic: topic, channel: channel).
+        process_next_message
+
+      expect(message).to have_received(:finish)
     end
   end
 
   describe '#go' do
-    # Infinite loops are untestable
+    describe 'when a SIGINT is received' do
+      it 'closes the consumer connection' do
+        ['INT', 'TERM'].each do |signal|
+          allow(SampleMessageProcessor).to receive_message_chain(:new, :go)
+          message = double(finish: nil, body: nil)
+          connection = double('Connection', pop: message, terminate: nil)
+          consumer = double('Consumer', connection: connection)
+          allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
+          topic = 'minitest'
+          channel = 'northstar'
+
+          pid = fork do
+            MessageQueue::Listener.new(topic: topic, channel: channel).go
+          end
+
+          Process.kill(signal, pid)
+
+          # Success for this test is to expect it to complete
+        end
+      end
+    end
   end
 end

--- a/spec/lib/fastly_nsq/message_queue/producer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/producer_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe MessageQueue::Producer do
   describe '#connection' do
     describe 'when using the real queue' do
       it 'returns an instance of the queue producer' do
-        MessageQueue::FALSY_VALUES.each do |no|
-          allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(no)
+        use_real_connection do
           allow(Nsq::Producer).to receive(:new)
           topic = 'death_star'
 
@@ -19,34 +18,67 @@ RSpec.describe MessageQueue::Producer do
         end
       end
     end
-  end
 
-  describe 'when using the fake queue' do
-    it 'returns an instance of the queue producer' do
-      MessageQueue::TRUTHY_VALUES.each do |yes|
-        allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(yes)
-        allow(FakeMessageQueue::Producer).to receive(:new)
+    describe 'when using the fake queue' do
+      it 'returns an instance of the queue producer' do
+        use_fake_connection do
+          allow(FakeMessageQueue::Producer).to receive(:new)
+          topic = 'death_star'
+
+          MessageQueue::Producer.new(topic: topic).connection
+
+          expect(FakeMessageQueue::Producer).to have_received(:new).
+            with(
+              nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
+              topic: topic,
+          ).at_least(:once)
+        end
+      end
+    end
+
+    describe 'when the ENV is set incorrectly' do
+      it 'raises with a helpful error' do
+        allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return('taco')
         topic = 'death_star'
 
-        MessageQueue::Producer.new(topic: topic).connection
+        producer = MessageQueue::Producer.new(topic: topic)
 
-        expect(FakeMessageQueue::Producer).to have_received(:new).
-          with(
-            nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
-            topic: topic,
-        ).at_least(:once)
+        expect{ producer.connection }.to raise_error(InvalidParameterError)
       end
     end
   end
 
-  describe 'when the ENV is set incorrectly' do
-    it 'raises with a helpful error' do
-      allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return('taco')
-      topic = 'death_star'
+  describe '#terminate' do
+    describe 'when using the real queue' do
+      it 'closes the connection' do
+        use_real_connection do
+          producer = double('Producer', connection: nil, terminate: nil)
+          allow(Nsq::Producer).to receive(:new).and_return(producer)
+          topic = 'death_star'
 
-      producer = MessageQueue::Producer.new(topic: topic)
+          live_producer = MessageQueue::Producer.new(topic: topic)
+          live_producer.connection
+          live_producer.terminate
 
-      expect{ producer.connection }.to raise_error(InvalidParameterError)
+          expect(producer).to have_received(:terminate)
+        end
+      end
+    end
+
+    describe 'when using the fake queue' do
+      it 'closes the connection' do
+        use_fake_connection do
+          producer = double('Producer', connection: nil, terminate: nil)
+          allow(FakeMessageQueue::Producer).to receive(:new).and_return(producer)
+          topic = 'death_star'
+
+          live_producer = MessageQueue::Producer.new(topic: topic)
+          live_producer.connection
+          live_producer.terminate
+
+          expect(producer).to have_received(:terminate)
+        end
+      end
     end
   end
 end

--- a/spec/lib/fastly_nsq/sample_message_processor_spec.rb
+++ b/spec/lib/fastly_nsq/sample_message_processor_spec.rb
@@ -4,37 +4,24 @@ RSpec.describe SampleMessageProcessor do
   describe '#start' do
     it 'enqueues the appropriate message processor' do
       data =  { 'key' => 'value' }
-      body = { 'event_type' => 'heartbeat', 'data' => data }.to_json
-      message = double('Message', body: body, finish: nil)
+      message_body = { 'event_type' => 'heartbeat', 'data' => data }.to_json
       allow(HeartbeatWorker).to receive(:perform_async)
 
-      SampleMessageProcessor.new(message).go
+      SampleMessageProcessor.new(message_body).go
 
       expect(HeartbeatWorker).to have_received(:perform_async).with(data)
-    end
-
-    it 'finishes the message' do
-      data =  { 'key' => 'value' }
-      body = { 'event_type' => 'heartbeat', 'data' => data }.to_json
-      message = double('Message', body: body, finish: nil)
-      allow(HeartbeatWorker).to receive(:perform_async)
-
-      SampleMessageProcessor.new(message).go
-
-      expect(message).to have_received(:finish)
     end
 
     describe 'when the message event_type is not known' do
       it 'uses the null object processor' do
         data = { 'sample_key' => 'sample value' }
-        body = {
+        message_body = {
           'event_type' => 'unregistered_message_type',
           'data' => data,
         }.to_json
-        message = double('Message', body: body, finish: nil)
         allow(UnknownMessageWorker).to receive(:perform_async)
 
-        SampleMessageProcessor.new(message).go
+        SampleMessageProcessor.new(message_body).go
 
         expect(UnknownMessageWorker).to have_received(:perform_async).with(data)
       end
@@ -43,14 +30,13 @@ RSpec.describe SampleMessageProcessor do
     describe 'when the message lacks an event_type' do
       it 'uses the null object processor' do
         data = { 'sample_key' => 'sample value' }
-        body = {
+        message_body = {
           'not_the_event_type_key' => 'unregistered_message_type',
           'data' => data,
         }.to_json
-        message = double('Message', body: body, finish: nil)
         allow(UnknownMessageWorker).to receive(:perform_async)
 
-        SampleMessageProcessor.new(message).go
+        SampleMessageProcessor.new(message_body).go
 
         expect(UnknownMessageWorker).to have_received(:perform_async).with(data)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'awesome_print'
 require 'pry-byebug'
 
 require_relative '../lib/fastly_nsq/sample_message_processor'
+require_relative 'support/env_helpers'
 
 MessageProcessor = SampleMessageProcessor
 
@@ -19,20 +20,18 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.example_status_persistence_file_path = 'spec/examples.txt'
   config.filter_run :focus
-  config.run_all_when_everything_filtered = true
-
-  config.profile_examples = 1
   config.order = :random
+  config.profile_examples = false
+  config.run_all_when_everything_filtered = true
   Kernel.srand config.seed
 
   if config.files_to_run.one?
     config.default_formatter = 'doc'
-    config.profile_examples = false
   end
 
   config.before(:each) do
     load_sample_environment_variables
-  #   FakeMessageQueue.reset!
+    FakeMessageQueue.reset!
   end
 
   def load_sample_environment_variables

--- a/spec/support/env_helpers.rb
+++ b/spec/support/env_helpers.rb
@@ -1,0 +1,19 @@
+module EnvHelpers
+  def use_fake_connection
+    MessageQueue::TRUTHY_VALUES.each do |yes|
+      allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(yes)
+      yield
+    end
+  end
+
+  def use_real_connection
+    MessageQueue::FALSY_VALUES.each do |no|
+      allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(no)
+      yield
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include EnvHelpers
+end


### PR DESCRIPTION
# Reason for Change
- The consumer and producers are leaving orphaned NSQ connections because we are not closing them.
- The listener should not care about finishing the message. Right now, it knows about the behavior of a `message`, but really should only care about JSON.
# Changes
- Have the `QueueListener` close the consumer connection after processing a message.
- Add connection termination to the consumer and producer classes.
- Extract spec helpers for using the real and fake queues.
- Correct documentation to reflect the new thinking.
- Bump the minor version.
# Minor
- Send JSON-only over to the processor.
- Move the message finishing back up to the listener. The `MessageProcessor` need not know about finishing messages. This couples the behavior to another class.
- Correct bad nesting in spec `describe` blocks.

https://jira.corp.fastly.com/browse/HYD-625
