### PR TITLE
Implement termination of the fake connections

### DIFF
--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -22,6 +22,10 @@ module FakeMessageQueue
       queue.push(message)
     end
 
+    def terminate
+      # noop
+    end
+
     private
 
     def queue
@@ -39,6 +43,10 @@ module FakeMessageQueue
 
     def size
       queue.size
+    end
+
+    def terminate
+      # noop
     end
 
     private

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe FakeMessageQueue::Producer do
       expect(FakeMessageQueue.queue.size).to eq 1
     end
   end
+
+  describe '#terminate' do
+    it 'has a terminate method which is a noop' do
+      producer = instance_double('FakeMessageQueue::Producer')
+      allow(producer).to receive(:terminate)
+    end
+  end
 end
 
 RSpec.describe FakeMessageQueue::Message do
@@ -99,6 +106,13 @@ RSpec.describe FakeMessageQueue::Consumer do
       popped_message = consumer.pop
 
       expect(popped_message). to eq message
+    end
+  end
+
+  describe '#terminate' do
+    it 'has a terminate method which is a noop' do
+      consumer = instance_double('FakeMessageQueue::Consumer')
+      allow(consumer).to receive(:terminate)
     end
   end
 end


### PR DESCRIPTION
# Reason for Change
- The real `Nsq::Producer/Consumer` have a `.terminate` method which closes the connection.
- The Fake lacks this, so we see some errors.
# Changes
- Implement terminate for fake producer and consumer
- Test them using RSpec's verifying instance double. If the method does not exist, RSpec will error.
