### PR TITLE
Raise custom exeception for empty fake queue

### DIFF
--- a/lib/fastly_nsq/message_queue/listener.rb
+++ b/lib/fastly_nsq/message_queue/listener.rb
@@ -30,6 +30,12 @@ module MessageQueue
       message = consumer.pop
       MessageProcessor.new(message.body).go
       message.finish
+    rescue NoMethodError => exception
+      if exception.message =~ /method \`body/
+        raise EmptyFakeQueueError.new
+      else
+        raise exception
+      end
     end
 
     attr_reader :channel, :topic
@@ -46,5 +52,17 @@ module MessageQueue
       consumer.terminate
       exit
     end
+  end
+end
+
+class EmptyFakeQueueError < StandardError
+  def initialize(message=default_message)
+    super
+  end
+
+  private
+
+  def default_message
+    'You are using the fake queue with no messages and trying to get messages.'
   end
 end

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe MessageQueue::Listener do
       connection = double('Connection', pop: message, terminate: nil)
       consumer = double('Consumer', connection: connection)
       allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
-      topic = 'minitest'
-      channel = 'northstar'
+      topic = 'testing_topic'
+      channel = 'testing_channel'
 
       MessageQueue::Listener.new(topic: topic, channel: channel).
         process_next_message
@@ -26,8 +26,8 @@ RSpec.describe MessageQueue::Listener do
       connection = double('Connection', pop: message, terminate: nil)
       consumer = double('Consumer', connection: connection)
       allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
-      topic = 'minitest'
-      channel = 'northstar'
+      topic = 'testing_topic'
+      channel = 'testing_channel'
 
       MessageQueue::Listener.new(topic: topic, channel: channel).
         process_next_message
@@ -42,13 +42,28 @@ RSpec.describe MessageQueue::Listener do
       connection = double('Connection', pop: message, terminate: nil)
       consumer = double('Consumer', connection: connection)
       allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
-      topic = 'minitest'
-      channel = 'northstar'
+      topic = 'testing_topic'
+      channel = 'testing_channel'
 
       MessageQueue::Listener.new(topic: topic, channel: channel).
         process_next_message
 
       expect(message).to have_received(:finish)
+    end
+
+    context 'when using the fake queue and it is empty' do
+      it 'offers a helpful exception message' do
+        MessageQueue::TRUTHY_VALUES.each do |yes|
+          allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(yes)
+          topic = 'testing_topic'
+          channel = 'testing_channel'
+
+          expect {
+            MessageQueue::Listener.new(topic: topic, channel: channel).
+            process_next_message
+          }.to raise_error(EmptyFakeQueueError, /fake queue with no messages/)
+        end
+      end
     end
   end
 
@@ -60,8 +75,8 @@ RSpec.describe MessageQueue::Listener do
         connection = double('Connection', pop: message, terminate: nil)
         consumer = double('Consumer', connection: connection)
         allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
-        topic = 'minitest'
-        channel = 'northstar'
+        topic = 'testing_topic'
+        channel = 'testing_channel'
 
         pid = fork do
           MessageQueue::Listener.new(topic: topic, channel: channel).go


### PR DESCRIPTION
# Reason for Change
- The fake queue will return an unhelpful exception when trying to `.pop` messages off of an empty queue.
- This is because the real queue will block until there is a message, but our fake is just an array, hence `nil`.
- That error is `NoMethodError: undefined method 'body' for nil:NilClass`.
- We should be more considerate to users of this library and explain what this means.
# Changes
- Add a custom `EmptyFakeQueueError` class with better message about what is actually going on.
- Raise this error in the case described above.
- Reraise any other errors to allow normal exception stuff to happen.
# Minor
- Replace `minitest` as a the placeholder testing channel topic name.
