### PR TITLE
Have the fake consumer block on an empty queue

### DIFF
--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -34,11 +34,20 @@ module FakeMessageQueue
   end
 
   class Consumer
+    SECONDS_BETWEEN_MESSAGE_QUEUE_CHECKS = 1
+
     def initialize(nsqlookupd:, topic:, channel:)
     end
 
     def pop
-      queue.pop
+      message = nil
+
+      until message do
+        message = queue.pop
+        sleep SECONDS_BETWEEN_MESSAGE_QUEUE_CHECKS
+      end
+
+      message
     end
 
     def size

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -1,16 +1,12 @@
 module FakeMessageQueue
-  @@queue = []
+  @@queue = Queue.new
 
   def self.queue
     @@queue
   end
 
-  def self.queue=(message)
-    @@queue = message
-  end
-
   def self.reset!
-    self.queue = []
+    self.queue.clear
   end
 
   class Producer
@@ -34,20 +30,11 @@ module FakeMessageQueue
   end
 
   class Consumer
-    SECONDS_BETWEEN_MESSAGE_QUEUE_CHECKS = 1
-
     def initialize(nsqlookupd:, topic:, channel:)
     end
 
     def pop
-      message = nil
-
-      until message do
-        message = queue.pop
-        sleep SECONDS_BETWEEN_MESSAGE_QUEUE_CHECKS
-      end
-
-      message
+      queue.pop
     end
 
     def size

--- a/lib/fastly_nsq/message_queue/listener.rb
+++ b/lib/fastly_nsq/message_queue/listener.rb
@@ -30,12 +30,6 @@ module MessageQueue
       message = consumer.pop
       MessageProcessor.new(message.body).go
       message.finish
-    rescue NoMethodError => exception
-      if exception.message =~ /method \`body/
-        raise EmptyFakeQueueError.new
-      else
-        raise exception
-      end
     end
 
     attr_reader :channel, :topic
@@ -52,17 +46,5 @@ module MessageQueue
       consumer.terminate
       exit
     end
-  end
-end
-
-class EmptyFakeQueueError < StandardError
-  def initialize(message=default_message)
-    super
-  end
-
-  private
-
-  def default_message
-    'You are using the fake queue with no messages and trying to get messages.'
   end
 end

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe MessageQueue::Listener do
     end
 
     context 'when using the fake queue and it is empty' do
-      it 'blocks on the process for longer than a half second' do
+      it 'blocks on the process, waiting for a message ' do
         MessageQueue::TRUTHY_VALUES.each do |yes|
           allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(yes)
           topic = 'testing_topic'
           channel = 'testing_channel'
 
           expect {
-            Timeout::timeout(0.5) do
+            Timeout::timeout(0.1) do
               MessageQueue::Listener.new(topic: topic, channel: channel).
                 process_next_message
             end


### PR DESCRIPTION
# Reason for Change
- When using `FAKE_QUEUE=true` in the dev VM, William's listener rake task fails horribly because the fake queue does not block on an empty queue.
# Changes
- Block on the empty queue when in fake mode.
## Minor
- Update the language in a spec's comments for clarity.
# Testing
- Tested this gem branch in William and all worked nicely.

https://jira.corp.fastly.com/browse/HYD-686
