### PR TITLE
Allow a logger to be defined on underlying nsq gem

### DIFF
--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -1,5 +1,6 @@
 module FakeMessageQueue
   @@queue = Queue.new
+  @@logger = Logger.new(nil)
 
   def self.queue
     @@queue
@@ -7,6 +8,14 @@ module FakeMessageQueue
 
   def self.reset!
     self.queue.clear
+  end
+
+  def self.logger=(logger)
+    @@logger = logger
+  end
+
+  def self.logger
+    @@logger
   end
 
   class Producer

--- a/lib/fastly_nsq/message_queue.rb
+++ b/lib/fastly_nsq/message_queue.rb
@@ -8,4 +8,16 @@ require_relative 'message_queue/strategy'
 module MessageQueue
   FALSY_VALUES = [false, 0, '0', 'false', 'FALSE', 'off', 'OFF', nil]
   TRUTHY_VALUES = [true, 1, '1', 'true', 'TRUE', 'on', 'ON']
+
+  def self.logger=(logger)
+    strategy.logger = logger
+  end
+
+  def self.logger
+    strategy.logger
+  end
+
+  def self.strategy
+    Strategy.for_queue
+  end
 end

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -10,6 +10,23 @@ RSpec.describe FakeMessageQueue do
     end
   end
 
+  describe '@@logger' do
+    after do
+      FakeMessageQueue.logger = Logger.new(nil)
+    end
+
+    it 'is initalized as an empty Ruby Logger' do
+      expect(FakeMessageQueue.logger).to be_a Logger
+    end
+
+    it 'can be set and retrieved' do
+      logger = double('some logger')
+      FakeMessageQueue.logger = logger
+
+      expect(FakeMessageQueue.logger).to eq logger
+    end
+  end
+
   describe '.reset!' do
     it 'resets the fake message queue' do
       FakeMessageQueue.queue.push('hello')

--- a/spec/lib/fastly_nsq/message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe MessageQueue do
+  describe '.logger' do
+    describe 'when using the fake queue' do
+      it 'allows the logger to be set and retrieved' do
+        use_fake_connection do
+          logger = Logger.new(STDOUT)
+          MessageQueue.logger = logger
+
+          expect(MessageQueue.logger).to eq logger
+        end
+      end
+    end
+
+    describe 'when using the real queue' do
+      it 'allows the logger to be set and retrieved' do
+        use_real_connection do
+          logger = Logger.new(STDOUT)
+          MessageQueue.logger = logger
+
+          expect(MessageQueue.logger).to eq logger
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here we allow for a passthru of `.logger=` and `.logger` to the wistia/ruby-nsq gem so that we can override the default logger of `Logger.new(nil)`. This should allow us to setup the nsq gem logger to be something like `Rails.logger` or some other logger as is needed.

Changes:
- Add two methods on `MessageQueue` (`.logger=` and `.logger`)
- Support those methods on `FakeMessageQueue`
- Tests for these methods
