### PR TITLE
Add RSpec fake_queue: true|false flags

### DIFF
--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -2,41 +2,37 @@ require 'spec_helper'
 
 RSpec.describe MessageQueue::Consumer do
   describe '#connection' do
-    describe 'when using the real queue' do
+    describe 'when using the real queue', fake_queue: false do
       it 'returns an instance of the queue consumer' do
-        use_real_connection do
-          allow(Nsq::Consumer).to receive(:new)
-          topic = 'death_star'
-          channel = 'star_killer_base'
+        allow(Nsq::Consumer).to receive(:new)
+        topic = 'death_star'
+        channel = 'star_killer_base'
 
-          MessageQueue::Consumer.new(topic: topic, channel: channel).connection
+        MessageQueue::Consumer.new(topic: topic, channel: channel).connection
 
-          expect(Nsq::Consumer).to have_received(:new).
-            with(
-              nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
-              topic: topic,
-              channel: channel,
-          ).at_least(:once)
-        end
+        expect(Nsq::Consumer).to have_received(:new).
+          with(
+            nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
+            topic: topic,
+            channel: channel,
+        ).at_least(:once)
       end
     end
 
-    describe 'when using the fake queue' do
+    describe 'when using the fake queue', fake_queue: true do
       it 'returns an instance of the queue consumer' do
-        use_fake_connection do
-          allow(FakeMessageQueue::Consumer).to receive(:new)
-          topic = 'death_star'
-          channel = 'star_killer_base'
+        allow(FakeMessageQueue::Consumer).to receive(:new)
+        topic = 'death_star'
+        channel = 'star_killer_base'
 
-          MessageQueue::Consumer.new(topic: topic, channel: channel).connection
+        MessageQueue::Consumer.new(topic: topic, channel: channel).connection
 
-          expect(FakeMessageQueue::Consumer).to have_received(:new).
-            with(
-              nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
-              topic: topic,
-              channel: channel,
-          ).at_least(:once)
-        end
+        expect(FakeMessageQueue::Consumer).to have_received(:new).
+          with(
+            nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
+            topic: topic,
+            channel: channel,
+        ).at_least(:once)
       end
     end
   end
@@ -54,39 +50,35 @@ RSpec.describe MessageQueue::Consumer do
   end
 
   describe '#terminate' do
-    describe 'when using the real queue' do
+    describe 'when using the real queue', fake_queue: false do
       it 'closes the connection' do
-        use_real_connection do
-          consumer = double('Consumer', connection: nil, terminate: nil)
-          allow(Nsq::Consumer).to receive(:new).and_return(consumer)
-          topic = 'death_star'
-          channel = 'star_killer_base'
-          params = { topic: topic, channel: channel }
+        consumer = double('Consumer', connection: nil, terminate: nil)
+        allow(Nsq::Consumer).to receive(:new).and_return(consumer)
+        topic = 'death_star'
+        channel = 'star_killer_base'
+        params = { topic: topic, channel: channel }
 
-          live_consumer = MessageQueue::Consumer.new(params)
-          live_consumer.connection
-          live_consumer.terminate
+        live_consumer = MessageQueue::Consumer.new(params)
+        live_consumer.connection
+        live_consumer.terminate
 
-          expect(consumer).to have_received(:terminate)
-        end
+        expect(consumer).to have_received(:terminate)
       end
     end
 
-    describe 'when using the fake queue' do
+    describe 'when using the fake queue', fake_queue: true do
       it 'closes the connection' do
-        use_fake_connection do
-          consumer = double('Consumer', connection: nil, terminate: nil)
-          allow(FakeMessageQueue::Consumer).to receive(:new).and_return(consumer)
-          topic = 'death_star'
-          channel = 'star_killer_base'
-          params = { topic: topic, channel: channel }
+        consumer = double('Consumer', connection: nil, terminate: nil)
+        allow(FakeMessageQueue::Consumer).to receive(:new).and_return(consumer)
+        topic = 'death_star'
+        channel = 'star_killer_base'
+        params = { topic: topic, channel: channel }
 
-          live_consumer = MessageQueue::Consumer.new(params)
-          live_consumer.connection
-          live_consumer.terminate
+        live_consumer = MessageQueue::Consumer.new(params)
+        live_consumer.connection
+        live_consumer.terminate
 
-          expect(consumer).to have_received(:terminate)
-        end
+        expect(consumer).to have_received(:terminate)
       end
     end
   end

--- a/spec/lib/fastly_nsq/message_queue/producer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/producer_spec.rb
@@ -2,37 +2,33 @@ require 'spec_helper'
 
 RSpec.describe MessageQueue::Producer do
   describe '#connection' do
-    describe 'when using the real queue' do
+    describe 'when using the real queue', fake_queue: false do
       it 'returns an instance of the queue producer' do
-        use_real_connection do
-          allow(Nsq::Producer).to receive(:new)
-          topic = 'death_star'
+        allow(Nsq::Producer).to receive(:new)
+        topic = 'death_star'
 
-          MessageQueue::Producer.new(topic: topic).connection
+        MessageQueue::Producer.new(topic: topic).connection
 
-          expect(Nsq::Producer).to have_received(:new).
-            with(
-              nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
-              topic: topic,
-          ).at_least(:once)
-        end
+        expect(Nsq::Producer).to have_received(:new).
+          with(
+            nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
+            topic: topic,
+        ).at_least(:once)
       end
     end
 
-    describe 'when using the fake queue' do
+    describe 'when using the fake queue', fake_queue: true do
       it 'returns an instance of the queue producer' do
-        use_fake_connection do
-          allow(FakeMessageQueue::Producer).to receive(:new)
-          topic = 'death_star'
+        allow(FakeMessageQueue::Producer).to receive(:new)
+        topic = 'death_star'
 
-          MessageQueue::Producer.new(topic: topic).connection
+        MessageQueue::Producer.new(topic: topic).connection
 
-          expect(FakeMessageQueue::Producer).to have_received(:new).
-            with(
-              nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
-              topic: topic,
-          ).at_least(:once)
-        end
+        expect(FakeMessageQueue::Producer).to have_received(:new).
+          with(
+            nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
+            topic: topic,
+        ).at_least(:once)
       end
     end
 
@@ -49,35 +45,31 @@ RSpec.describe MessageQueue::Producer do
   end
 
   describe '#terminate' do
-    describe 'when using the real queue' do
+    describe 'when using the real queue', fake_queue: false do
       it 'closes the connection' do
-        use_real_connection do
-          producer = double('Producer', connection: nil, terminate: nil)
-          allow(Nsq::Producer).to receive(:new).and_return(producer)
-          topic = 'death_star'
+        producer = double('Producer', connection: nil, terminate: nil)
+        allow(Nsq::Producer).to receive(:new).and_return(producer)
+        topic = 'death_star'
 
-          live_producer = MessageQueue::Producer.new(topic: topic)
-          live_producer.connection
-          live_producer.terminate
+        live_producer = MessageQueue::Producer.new(topic: topic)
+        live_producer.connection
+        live_producer.terminate
 
-          expect(producer).to have_received(:terminate)
-        end
+        expect(producer).to have_received(:terminate)
       end
     end
 
-    describe 'when using the fake queue' do
+    describe 'when using the fake queue', fake_queue: true do
       it 'closes the connection' do
-        use_fake_connection do
-          producer = double('Producer', connection: nil, terminate: nil)
-          allow(FakeMessageQueue::Producer).to receive(:new).and_return(producer)
-          topic = 'death_star'
+        producer = double('Producer', connection: nil, terminate: nil)
+        allow(FakeMessageQueue::Producer).to receive(:new).and_return(producer)
+        topic = 'death_star'
 
-          live_producer = MessageQueue::Producer.new(topic: topic)
-          live_producer.connection
-          live_producer.terminate
+        live_producer = MessageQueue::Producer.new(topic: topic)
+        live_producer.connection
+        live_producer.terminate
 
-          expect(producer).to have_received(:terminate)
-        end
+        expect(producer).to have_received(:terminate)
       end
     end
   end

--- a/spec/lib/fastly_nsq/message_queue/strategy_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/strategy_spec.rb
@@ -2,27 +2,19 @@ require 'spec_helper'
 
 RSpec.describe Strategy do
   describe '.for_queue' do
-    describe 'when using the fake queue' do
+    describe 'when using the fake queue', fake_queue: true do
       it 'returns the strategy based on the ENV variable' do
-        MessageQueue::TRUTHY_VALUES.each do |yes|
-          allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(yes)
+        strategy = Strategy.for_queue
 
-          strategy = Strategy.for_queue
-
-          expect(strategy).to eq FakeMessageQueue
-        end
+        expect(strategy).to eq FakeMessageQueue
       end
     end
 
-    describe 'when using the real queue' do
+    describe 'when using the real queue', fake_queue: false do
       it 'returns the strategy based on the ENV variable' do
-        MessageQueue::FALSY_VALUES.each do |no|
-          allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(no)
+        strategy = Strategy.for_queue
 
-          strategy = Strategy.for_queue
-
-          expect(strategy).to eq Nsq
-        end
+        expect(strategy).to eq Nsq
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,22 @@ RSpec.configure do |config|
     FakeMessageQueue.reset!
   end
 
+  config.around(:each, fake_queue: true) do |example|
+    RSpec::Mocks.with_temporary_scope do
+      use_fake_connection do
+        example.run
+      end
+    end
+  end
+
+  config.around(:each, fake_queue: false) do |example|
+    RSpec::Mocks.with_temporary_scope do
+      use_real_connection do
+        example.run
+      end
+    end
+  end
+
   def load_sample_environment_variables
     env_file = File.open('env_configuration_for_local_gem_tests.yml')
 


### PR DESCRIPTION
# Reason for Change
- Our tests increasingly depend on setting the queue as fake or real.
- We had these `ENV` helpers already, adding these tags makes their use easier.
# Changes
- Add RSpec around configs to use the flags `fake_queue: true` and `fake_queue: false` in specs.
- Update existing tests to use these flags.
