### PR TITLE
Revert use of a Ruby Queue in the fake

### DIFF
--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -1,5 +1,6 @@
 module FakeMessageQueue
   @@logger = Logger.new(nil)
+  @@queue = []
 
   def self.queue
     @@queue

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -1,13 +1,16 @@
 module FakeMessageQueue
-  @@queue = Queue.new
   @@logger = Logger.new(nil)
 
   def self.queue
     @@queue
   end
 
+  def self.queue=(message)
+    @@queue = message
+  end
+
   def self.reset!
-    self.queue.clear
+    self.queue = []
   end
 
   def self.logger=(logger)
@@ -39,11 +42,20 @@ module FakeMessageQueue
   end
 
   class Consumer
+    SECONDS_BETWEEN_QUEUE_CHECKS = 0.5
+
     def initialize(nsqlookupd:, topic:, channel:)
     end
 
     def pop
-      queue.pop
+      message = nil
+
+      until message do
+        message = queue.pop
+        sleep SECONDS_BETWEEN_QUEUE_CHECKS
+      end
+
+      message
     end
 
     def size

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -51,20 +51,18 @@ RSpec.describe MessageQueue::Listener do
       expect(message).to have_received(:finish)
     end
 
-    context 'when using the fake queue and it is empty' do
-      it 'blocks on the process, waiting for a message ' do
-        MessageQueue::TRUTHY_VALUES.each do |yes|
-          allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(yes)
-          topic = 'testing_topic'
-          channel = 'testing_channel'
+    context 'when using the fake queue and it is empty', fake_queue: true do
+      it 'blocks on the process for longer than the check cycle' do
+        topic = 'testing_topic'
+        channel = 'testing_channel'
+        delay = FakeMessageQueue::Consumer::SECONDS_BETWEEN_QUEUE_CHECKS + 0.1
 
-          expect {
-            Timeout::timeout(0.1) do
-              MessageQueue::Listener.new(topic: topic, channel: channel).
-                process_next_message
-            end
-          }.to raise_error(Timeout::Error)
-        end
+        expect {
+          Timeout::timeout(delay) do
+            MessageQueue::Listener.new(topic: topic, channel: channel).
+              process_next_message
+          end
+        }.to raise_error(Timeout::Error)
       end
     end
   end


### PR DESCRIPTION
# Reason for Change
- The conversion to use a Ruby `Queue` in c6603df was ill-considered.
- Specifically, a `Queue` can push items in on the main process but needs to be in a thread to `.pop`.
- Really, an Array is fine and does the job with no troubles, so this reverts that change.
# List of Changes
- Describe your changes
- As a concise list of items
# Changes
- This reverts commit c6603df.
# Minor
- Use a shorter constant name and use it in the tests.
- Have the test take longer than one cycle of checking for the fake queue.
- Use the `fake_queue` flag in a spec which got missed in the conversion.
# Checklist
- [X] I have linked to all relevant reference issues or work requests
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added or updated necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream
# Recommended Reviewers

@alieander, @standingwave 
