### PR TITLE
Listen to multiple queues at once

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Checklist
 _Put an `x` in the boxes that apply. 
 You can also fill these out after creating the PR._
 
-- [ ] I have linked to all relavant reference issues or work requests
+- [ ] I have linked to all relevant reference issues or work requests
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added or updated necessary documentation (if appropriate)
 - [ ] Any dependent changes have been merged and published in downstream

--- a/examples/Rakefile
+++ b/examples/Rakefile
@@ -1,41 +1,88 @@
-require 'fastly_nsq'
 require 'fastly_nsq/rake_task'
 
-##
-# Both topic and channel will need to be passed into the rake task when
-# it is called.
-#
-# ex: `rake listen_task[my_topic,my_channel]`
-# topic will be 'my_topic' and channel will be 'my_channel'
-#
-MessageQueue::RakeTask.new(:listen_task, [:topic, :channel])
+#-------------------------------------------------------------------------------
+# You are required to to set the topics in MessageProcessor.topics as an array:
 
-##
-# In Rails, you can include the environment like so:
-#
-MessageQueue::RakeTask.new(:listen_task, [:topic, :channel] => :environment)
+class MessageProcessor
+  def self.topics
+    ['customer_created', 'customer_deleted']
+  end
 
-##
-# Topic and channel can also be preset in the task by passing a block and
-# assigning value like so. This is useful if you want a single purpose
-# listener task.
+  # ...
+end
+
+# A channel will need to be passed in
+# to the Rake task
+# when it is called.
 #
-# ex: `rake listen_task`
-# topic will be 'some_topic' and channel will be 'some_channel'
-#
+# The task looks like:
+
+desc 'Listen to the messaging queue with the given channel.'
+
+MessageQueue::RakeTask.new(:listen_task, [:channel])
+
+# Call `rake listen_task[my_channel]`.
+# The topics will be ['customer_created', 'customer_deleted']
+# and channel will be 'my_channel'.
+
+#-------------------------------------------------------------------------------
+# In Rails, you can include the application environment. The task looks like:
+
+desc 'Listen to the messaging queue with the given channel.'
+
+MessageQueue::RakeTask.new(:listen_task, [:channel] => :environment)
+
+# Call `rake listen_task[your_channel]`.
+# The topics will be ['customer_created', 'customer_deleted']
+# and channel will be 'your_channel'.
+
+#-------------------------------------------------------------------------------
+# The channel can also be preset in the task
+# by passing a block and assigning the value. The task looks like:
+
+desc 'Listen to the messaging queue with the given channel.'
+
 MessageQueue::RakeTask.new(:listen_task) do |task|
-  task.topic   = 'some_topic'
   task.channel = 'some_channel'
 end
 
-##
-# Both forms can be combine to provide defaults of a sort with the ability
-# to override at time of rake call
-#
-# ex: `rake listen_task[altered_topic]`
-# topic will be 'altered_topic' and channel will be 'some_channel'
-#
-MessageQueue::RakeTask.new(:listen_task, [:topic, :channel]) do |task|
-  task.topic   = 'some_topic'
-  task.channel = 'some_channel'
+# Call `rake listen_task`.
+# The topics will be ['customer_created', 'customer_deleted']
+# and channel will be 'some_channel'.
+
+#-------------------------------------------------------------------------------
+# Do the same thing and include the environment:
+
+desc 'Listen to the messaging queue with the given channel.'
+
+MessageQueue::RakeTask.new(:listen_task, [] => :environment) do |task|
+  task.channel = 'her_channel'
 end
+
+# Call `rake listen_task`.
+# The topics will be ['customer_created', 'customer_deleted']
+# and channel will be 'her_channel'.
+
+#-------------------------------------------------------------------------------
+# Both forms can be combined
+# to provide defaults
+# with the ability to override at time of Rake call:
+
+MessageQueue::RakeTask.new(:listen_task, [:channel]) do |task|
+  task.channel = 'default_channel'
+end
+
+# Call `rake listen_task[overridden_channel]`.
+# The topics will be ['customer_created', 'customer_deleted']
+# and channel will be 'overridden_channel'.
+
+#-------------------------------------------------------------------------------
+# The same, but including the environment:
+
+MessageQueue::RakeTask.new(:listen_task, [:channel] => :environment) do |task|
+  task.channel = 'default_channel'
+end
+
+# Call `rake listen_task[overridden_channel]`.
+# The topics will be ['customer_created', 'customer_deleted']
+# and channel will be 'overridden_channel'.

--- a/lib/fastly_nsq/message_queue/listener.rb
+++ b/lib/fastly_nsq/message_queue/listener.rb
@@ -26,13 +26,13 @@ module MessageQueue
 
     private
 
+    attr_reader :channel, :topic
+
     def process_one_message
       message = consumer.pop
-      MessageProcessor.new(message.body).go
+      MessageProcessor.new(message_body: message.body, topic: topic).go
       message.finish
     end
-
-    attr_reader :channel, :topic
 
     def consumer
       @consumer ||= MessageQueue::Consumer.new(consumer_params).connection

--- a/lib/fastly_nsq/sample_message_processor.rb
+++ b/lib/fastly_nsq/sample_message_processor.rb
@@ -11,12 +11,17 @@ class UnknownMessageWorker
 end
 
 class SampleMessageProcessor
-  EVENT_TYPE_TO_WORKER_MAP = {
+  TOPIC_TO_WORKER_MAP = {
     'heartbeat' => HeartbeatWorker,
   }.freeze
 
-  def initialize(message_body)
+  def self.topics
+    TOPIC_TO_WORKER_MAP.keys
+  end
+
+  def initialize(message_body:, topic:)
     @message_body = message_body
+    @topic = topic
   end
 
   def go
@@ -25,18 +30,14 @@ class SampleMessageProcessor
 
   private
 
-  attr_reader :message_body
+  attr_reader :message_body, :topic
 
   def process_message_body
     message_processor.perform_async(message_data)
   end
 
   def message_processor
-    EVENT_TYPE_TO_WORKER_MAP.fetch(event_type, UnknownMessageWorker)
-  end
-
-  def event_type
-    parsed_message_body['event_type']
+    TOPIC_TO_WORKER_MAP.fetch(topic, UnknownMessageWorker)
   end
 
   def message_data

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.2.3'
+  VERSION = '0.3.0'
 end

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe MessageQueue::Listener do
       MessageQueue::Listener.new(topic: topic, channel: channel).
         process_next_message
 
-      expect(MessageProcessor).to have_received(:new).with(message_body)
+      expect(MessageProcessor).to have_received(:new).
+        with(topic: topic, message_body: message_body)
       expect(process_message).to have_received(:go)
     end
 

--- a/spec/lib/fastly_nsq/message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue_spec.rb
@@ -2,25 +2,21 @@ require 'spec_helper'
 
 RSpec.describe MessageQueue do
   describe '.logger' do
-    describe 'when using the fake queue' do
+    describe 'when using the fake queue', fake_queue: true do
       it 'allows the logger to be set and retrieved' do
-        use_fake_connection do
-          logger = Logger.new(STDOUT)
-          MessageQueue.logger = logger
+        logger = Logger.new(STDOUT)
+        MessageQueue.logger = logger
 
-          expect(MessageQueue.logger).to eq logger
-        end
+        expect(MessageQueue.logger).to eq logger
       end
     end
 
-    describe 'when using the real queue' do
+    describe 'when using the real queue, fake_queue: false' do
       it 'allows the logger to be set and retrieved' do
-        use_real_connection do
-          logger = Logger.new(STDOUT)
-          MessageQueue.logger = logger
+        logger = Logger.new(STDOUT)
+        MessageQueue.logger = logger
 
-          expect(MessageQueue.logger).to eq logger
-        end
+        expect(MessageQueue.logger).to eq logger
       end
     end
   end

--- a/spec/lib/fastly_nsq/rake_task_spec.rb
+++ b/spec/lib/fastly_nsq/rake_task_spec.rb
@@ -3,71 +3,126 @@ require 'fastly_nsq/rake_task'
 
 RSpec.describe MessageQueue::RakeTask do
   before(:each) do
-    Rake::Task['begin_listening'].clear if Rake::Task.task_defined?('begin_listening')
+    Rake::Task.clear
+    allow_any_instance_of(MessageQueue::RakeTask).to receive(:output) { nil }
   end
 
   describe 'when defining tasks' do
-    it 'creates a begin_listening task' do
-      MessageQueue::RakeTask.new
+    context 'when no task name is provided' do
+      it 'creates a task with the default name' do
+        default_task_name = 'begin_listening'
 
-      allow_any_instance_of(MessageQueue::RakeTask).to receive(:output) { nil }
+        MessageQueue::RakeTask.new
+        defined_tasks = Rake::Task.tasks
+        first_task_name = defined_tasks.first.name
 
-      is_defined = Rake::Task.task_defined?(:begin_listening)
-      expect(is_defined).to be_truthy
+        expect(first_task_name).to eq default_task_name
+      end
     end
 
-    it 'creates a named task' do
-      MessageQueue::RakeTask.new(:test_name)
+    context 'when a task name is passed in' do
+      it 'creates a task with the provided name' do
+        task_name = 'test_name'
 
-      allow_any_instance_of(MessageQueue::RakeTask).to receive(:output) { nil }
+        MessageQueue::RakeTask.new(task_name.to_sym)
+        defined_tasks = Rake::Task.tasks
+        first_task_name = defined_tasks.first.name
 
-      is_defined = Rake::Task.task_defined?(:test_name)
-      expect(is_defined).to be_truthy
+        expect(first_task_name).to eq task_name
+      end
     end
   end
 
   describe 'when running tasks' do
-    it 'runs with inline options defined' do
-      options = { topic: 'dwarf', channel: 'star' }
-      task = MessageQueue::RakeTask.new(:begin_listening, [:topic, :channel])
+    context 'when multiple topics are defined' do
+      it 'creates a listener for each' do
+        channel = 'clown_generating_service'
+        topics = ['customer_created', 'customer_now_awesome']
+        allow(SampleMessageProcessor).to receive(:topics).and_return(topics)
+        message_queue_listener = double('listener', go: nil)
+        allow(MessageQueue::Listener).to receive(:new).
+          and_return(message_queue_listener)
 
-      message_queue_listener = double('go', go: nil)
-      expect(MessageQueue::Listener).to receive(:new).
-        with(options).
-        and_return(message_queue_listener)
+        MessageQueue::RakeTask.new(:begin_listening, [:channel])
+        Rake::Task['begin_listening'].execute(channel: channel)
 
-      allow_any_instance_of(MessageQueue::RakeTask).to receive(:output) { nil }
-      Rake::Task['begin_listening'].execute(topic: 'dwarf', channel: 'star')
+        topics.each do |topic|
+          expect(MessageQueue::Listener).to have_received(:new).
+            with(topic: topic, channel: channel)
+        end
+      end
     end
 
-    it 'runs with specified options if a block is given' do
+    it 'listens to the command-line-provided channel' do
+      channel = 'salesforce'
+      topics = ['customer_created']
+      allow(SampleMessageProcessor).to receive(:topics).and_return(topics)
+
+      message_queue_listener = double('listener', go: nil)
+      expect(MessageQueue::Listener).to receive(:new).
+        with(topic: topics.first, channel: channel).
+        and_return(message_queue_listener)
+
+      MessageQueue::RakeTask.new(:begin_listening, [:channel])
+      Rake::Task['begin_listening'].execute(channel: channel)
+    end
+
+    it 'runs with specified channel if a block is given' do
+      channel = 'send_new_customers_a_sticker_service'
+      topics = ['customer_created']
+      allow(SampleMessageProcessor).to receive(:topics).and_return(topics)
+
+      message_queue_listener = double('listener', go: nil)
+      expect(MessageQueue::Listener).to receive(:new).
+        with(topic: topics.first, channel: channel).
+        and_return(message_queue_listener)
+
       MessageQueue::RakeTask.new do |task|
-        task.topic   = 'dwarf'
-        task.channel = 'star'
+        task.channel = channel
       end
-
-      message_queue_listener = double('go', go: nil)
-      expect(MessageQueue::Listener).to receive(:new).
-        with(topic: 'dwarf', channel: 'star').
-        and_return(message_queue_listener)
-
-      allow_any_instance_of(MessageQueue::RakeTask).to receive(:output) { nil }
-      Rake::Task['begin_listening'].execute(topic: 'dwarf', channel: 'star')
+      Rake::Task['begin_listening'].execute(channel: channel)
     end
 
-    it 'uses inline definitions over block assignments' do
-      MessageQueue::RakeTask.new(:begin_listening, [:topic, :channel]) do |task|
-        task.topic   = 'loud'
-        task.channel = 'noise'
-      end
+    it 'prefers inline channel definition over block assignments' do
+      default_channel = 'throw_a_huge_pizza_party_service'
+      new_channel = 'send_balloons_to_customer_service'
+      topics = ['customer_created']
+      allow(SampleMessageProcessor).to receive(:topics).and_return(topics)
 
-      message_queue_listener = double('go', go: nil)
+      message_queue_listener = double('listener', go: nil)
       expect(MessageQueue::Listener).to receive(:new).
-        with(topic: 'dwarf', channel: 'star').
+        with(topic: topics.first, channel: new_channel).
         and_return(message_queue_listener)
 
-      allow_any_instance_of(MessageQueue::RakeTask).to receive(:output) { nil }
-      Rake::Task['begin_listening'].execute(topic: 'dwarf', channel: 'star')
+      MessageQueue::RakeTask.new(:begin_listening, [:channel]) do |task|
+        task.channel = default_channel
+      end
+      Rake::Task['begin_listening'].execute(channel: new_channel)
+    end
+
+    context 'when no channel is provided' do
+      it 'raises an error' do
+        topics = ['customer_created']
+        allow(SampleMessageProcessor).to receive(:topics).and_return(topics)
+
+        expect {
+          MessageQueue::RakeTask.new(:begin_listening, [:channel])
+          Rake::Task['begin_listening'].execute
+        }.to raise_error(ArgumentError, /channel is required/)
+      end
+    end
+
+    context 'when MessageProcessor.topics is not defined' do
+      it 'raises an error' do
+        channel = 'best_server_number_1'
+        allow(SampleMessageProcessor).to receive(:topics).
+          and_raise(NoMethodError, "undefined method `topics'")
+
+        expect {
+          MessageQueue::RakeTask.new(:begin_listening, [:channel])
+          Rake::Task['begin_listening'].execute(channel: channel)
+        }.to raise_error(ArgumentError, /MessageProcessor.topics is not defined/)
+      end
     end
   end
 end

--- a/spec/lib/fastly_nsq/sample_message_processor_spec.rb
+++ b/spec/lib/fastly_nsq/sample_message_processor_spec.rb
@@ -1,42 +1,35 @@
 require 'spec_helper'
 
 RSpec.describe SampleMessageProcessor do
-  describe '#start' do
-    it 'enqueues the appropriate message processor' do
-      data =  { 'key' => 'value' }
-      message_body = { 'event_type' => 'heartbeat', 'data' => data }.to_json
-      allow(HeartbeatWorker).to receive(:perform_async)
+  describe '.topics' do
+    it 'specifies the array of topics to listen to' do
+      topics = SampleMessageProcessor.topics
 
-      SampleMessageProcessor.new(message_body).go
+      expect(topics).to be_an Array
+      expect(topics.first).to be_a String
+    end
+  end
+
+  describe '#go' do
+    it 'enqueues the appropriate message processor' do
+      data = { 'key' => 'value' }
+      message_body = { 'data' => data }.to_json
+      allow(HeartbeatWorker).to receive(:perform_async)
+      topic = 'heartbeat'
+
+      SampleMessageProcessor.new(message_body: message_body, topic: topic).go
 
       expect(HeartbeatWorker).to have_received(:perform_async).with(data)
     end
 
-    describe 'when the message event_type is not known' do
+    describe 'when the message topic is not known' do
       it 'uses the null object processor' do
         data = { 'sample_key' => 'sample value' }
-        message_body = {
-          'event_type' => 'unregistered_message_type',
-          'data' => data,
-        }.to_json
+        message_body = { 'data' => data }.to_json
         allow(UnknownMessageWorker).to receive(:perform_async)
+        topic = 'unknown_topic'
 
-        SampleMessageProcessor.new(message_body).go
-
-        expect(UnknownMessageWorker).to have_received(:perform_async).with(data)
-      end
-    end
-
-    describe 'when the message lacks an event_type' do
-      it 'uses the null object processor' do
-        data = { 'sample_key' => 'sample value' }
-        message_body = {
-          'not_the_event_type_key' => 'unregistered_message_type',
-          'data' => data,
-        }.to_json
-        allow(UnknownMessageWorker).to receive(:perform_async)
-
-        SampleMessageProcessor.new(message_body).go
+        SampleMessageProcessor.new(message_body: message_body, topic: topic).go
 
         expect(UnknownMessageWorker).to have_received(:perform_async).with(data)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,6 @@ require 'pry-byebug'
 require_relative '../lib/fastly_nsq/sample_message_processor'
 require_relative 'support/env_helpers'
 
-MessageProcessor = SampleMessageProcessor
-
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -21,12 +19,16 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = 'spec/examples.txt'
   config.filter_run :focus
   config.order = :random
-  config.profile_examples = false
+  config.profile_examples = 1
   config.run_all_when_everything_filtered = true
   Kernel.srand config.seed
 
   if config.files_to_run.one?
     config.default_formatter = 'doc'
+  end
+
+  config.before(:suite) do
+    MessageProcessor = SampleMessageProcessor
   end
 
   config.before(:each) do


### PR DESCRIPTION
# Reason for Change
- As we've set up the topic listening machinery in the `fastly_nsq` gem, it is really geared toward listening to and processing one topic's messages.
- However, in some apps, we will shortly be processing messages from two topics simultaneously, so our system needs to handle > 1 queue topics simultaneous.
# Changes
- Don't pass topics into the Raketask, specify in `MessageProcessor.topics`.
- Remove the required `event_type` key from message bodies, in the examples and the documentation.
- Have the processor accept a topic as well as a message body.
- Rework the rake task to spawn a new thread for each topic.
- Update the example Rakefile to reflect the changes and documentation.
## Minor
- Bump version to 0.3.0.
- Extract some methods in the `RakeTask`.
- Style: Avoid trailing conditionals.
- Style: Avoid unused tempvars.
- Don't include both `fastly_nsq` and `fastly_nsq/rake_task` - no need.
- Profile the slowest example on full suite RSpec.
- Move the setting of the `MessageProcessor` class to a before block.
- Clear all rake tasks before each test; use context blocks.
- Prevent output during the tests and do it in the before block.
- Correct mislabeled describe block.
- Spelling error in pull request template.
## Risks
- This represents a breaking change to the APIs for the rake task and the MessageProcessor. All apps must be updated with this version bump to accomodate the change.
- The Rake task now uses threads, one for each topic monitored.

https://jira.corp.fastly.com/browse/HYD-735
# Checklist

_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._
- [X] I have linked to all relevant reference issues or work requests
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added or updated necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream
# Recommended Reviewers

@alieander, @standingwave 
