### PR TITLE
Add Rubocop and Overcommit

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,34 @@
+PreCommit:
+  ALL:
+    quiet: true
+    verify_signatures: false
+
+  MergeConflicts:
+    description: 'Checking for unaddressed merge conflicts'
+    enabled: true
+    quiet: true
+    required_executable: 'grep'
+    flags: ['-IHn', "^<<<<<<<[ \t]"]
+
+  RuboCop:
+    description: 'Checking Ruby style'
+    enabled: true
+    problem_on_unmodified_line: ignore
+    quiet: true
+    on_warn: fail
+
+CommitMsg:
+  ALL:
+    quiet: true
+  CapitalizedSubject:
+    description: 'Ensuring commit message subjects are capitalized'
+    enabled: false
+  EmptyMessage:
+    description: 'Prevent empty commit messages'
+    enabled: true
+  TextWidth:
+    description: 'Ensure commit message subjects are <60 chars'
+    enabled: true
+    description: 'Checking text width'
+    max_subject_width: 60
+    max_body_width: 1000

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,72 @@
+AllCops:
+  Include:
+    - '**/Rakefile'
+  Exclude:
+    - 'db/schema.rb'
+    - 'vendor/**/*'
+  TargetRubyVersion: 2.1
+
+LineLength:
+  Enabled: false
+
+HashSyntax:
+  Enabled: false
+
+BracesAroundHashParameters:
+  Enabled: false
+
+CollectionMethods:
+  Enabled: false
+
+CyclomaticComplexity:
+  Enabled: true
+
+Style/DotPosition:
+  Enabled: true
+  EnforcedStyle: trailing
+  SupportedStyles:
+    - leading
+    - trailing
+
+MethodLength:
+  Enabled: false
+
+PerlBackrefs:
+  Enabled: false
+
+RescueModifier:
+  Enabled: false
+
+GuardClause:
+  Enabled: false
+
+IfUnlessModifier:
+  Enabled: false
+
+ClassLength:
+  Enabled: false
+
+Style/ClassVars:
+  Description: 'Avoid the use of class variables.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'
+  Enabled: false
+
+Documentation:
+  Enabled: false
+
+RegexpLiteral:
+  Enabled: false
+
+SignalException:
+  EnforcedStyle: only_raise
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+  Enabled: true
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -17,8 +17,10 @@ require 'rdoc/task'
 RDoc::Task.new
 task doc: :rdoc
 
-require 'bundler/audit/cli'
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
 
+require 'bundler/audit/cli'
 namespace :bundler do
   desc 'Updates the ruby-advisory-db and runs audit'
   task :audit do
@@ -28,8 +30,8 @@ namespace :bundler do
   end
 end
 
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:spec)
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
 
 task(:default).clear
-task default: ['spec', 'bundler:audit']
+task default: ['spec', 'rubocop', 'bundler:audit']

--- a/examples/Rakefile
+++ b/examples/Rakefile
@@ -5,7 +5,7 @@ require 'fastly_nsq/rake_task'
 
 class MessageProcessor
   def self.topics
-    ['customer_created', 'customer_deleted']
+    %w(customer_created customer_deleted)
   end
 
   # ...

--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -23,10 +23,12 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'awesome_print', '~> 1.6'
   gem.add_development_dependency 'bundler', '~> 1.10'
   gem.add_development_dependency 'bundler-audit', '~> 0.4'
+  gem.add_development_dependency 'overcommit', '~> 0.32.0'
   gem.add_development_dependency 'pry-byebug', '~> 3.3'
   gem.add_development_dependency 'rake', '~> 10.5'
   gem.add_development_dependency 'rdoc', '~> 4.2'
   gem.add_development_dependency 'rspec', '~> 3.4'
+  gem.add_development_dependency 'rubocop', '~> 0.38.0'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
 
   gem.add_dependency 'nsq-ruby', '~> 1.5.0', '>= 1.5.0'

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -50,7 +50,7 @@ module FakeMessageQueue
     def pop
       message = nil
 
-      until message do
+      until message
         message = queue.pop
         sleep SECONDS_BETWEEN_QUEUE_CHECKS
       end

--- a/lib/fastly_nsq/message_queue.rb
+++ b/lib/fastly_nsq/message_queue.rb
@@ -6,8 +6,8 @@ require_relative 'message_queue/consumer'
 require_relative 'message_queue/strategy'
 
 module MessageQueue
-  FALSY_VALUES = [false, 0, '0', 'false', 'FALSE', 'off', 'OFF', nil]
-  TRUTHY_VALUES = [true, 1, '1', 'true', 'TRUE', 'on', 'ON']
+  FALSY_VALUES = [false, 0, '0', 'false', 'FALSE', 'off', 'OFF', nil].freeze
+  TRUTHY_VALUES = [true, 1, '1', 'true', 'TRUE', 'on', 'ON'].freeze
 
   def self.logger=(logger)
     strategy.logger = logger

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -1,4 +1,4 @@
-class InvalidParameterError < StandardError; end;
+class InvalidParameterError < StandardError; end
 
 module MessageQueue
   class Consumer

--- a/lib/fastly_nsq/message_queue/producer.rb
+++ b/lib/fastly_nsq/message_queue/producer.rb
@@ -1,4 +1,4 @@
-class InvalidParameterError < StandardError; end;
+class InvalidParameterError < StandardError; end
 
 module MessageQueue
   class Producer

--- a/lib/fastly_nsq/rake_task.rb
+++ b/lib/fastly_nsq/rake_task.rb
@@ -7,10 +7,7 @@ module MessageQueue
 
     def initialize(*args, &task_block)
       @name = args.shift || :begin_listening
-
-      unless ::Rake.application.last_comment
-        desc 'Listen to NSQ on topic using channel'
-      end
+      add_rake_task_description_if_one_needed
 
       task(name, *args) do |_, task_args|
         RakeFileUtils.send(:verbose, verbose) do
@@ -29,6 +26,12 @@ module MessageQueue
     end
 
     private
+
+    def add_rake_task_description_if_one_needed
+      unless ::Rake.application.last_comment
+        desc 'Listen to NSQ on topic using channel'
+      end
+    end
 
     def run_tasks
       topics.each do |topic|

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.3.0'
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -141,11 +141,11 @@ RSpec.describe FakeMessageQueue::Consumer do
           channel: channel,
         )
 
-        expect {
-          Timeout::timeout(delay) do
+        expect do
+          Timeout.timeout(delay) do
             consumer.pop
           end
-        }.to raise_error(Timeout::Error)
+        end.to raise_error(Timeout::Error)
       end
     end
   end

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MessageQueue::Consumer do
             nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
             topic: topic,
             channel: channel,
-        ).at_least(:once)
+          ).at_least(:once)
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe MessageQueue::Consumer do
             nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
             topic: topic,
             channel: channel,
-        ).at_least(:once)
+          ).at_least(:once)
       end
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe MessageQueue::Consumer do
 
       consumer = MessageQueue::Consumer.new(topic: topic, channel: channel)
 
-      expect{ consumer.connection }.to raise_error(InvalidParameterError)
+      expect { consumer.connection }.to raise_error(InvalidParameterError)
     end
   end
 

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe MessageQueue::Listener do
     it 'processes the message' do
       process_message = double(go: nil)
       allow(MessageProcessor).to receive(:new).and_return(process_message)
-      message_body = { data: 'value'  }.to_json
+      message_body = { data: 'value' }.to_json
       message = double('Message', finish: nil, body: message_body)
       connection = double('Connection', pop: message, terminate: nil)
       consumer = double('Consumer', connection: connection)
@@ -58,12 +58,12 @@ RSpec.describe MessageQueue::Listener do
         channel = 'testing_channel'
         delay = FakeMessageQueue::Consumer::SECONDS_BETWEEN_QUEUE_CHECKS + 0.1
 
-        expect {
-          Timeout::timeout(delay) do
+        expect do
+          Timeout.timeout(delay) do
             MessageQueue::Listener.new(topic: topic, channel: channel).
               process_next_message
           end
-        }.to raise_error(Timeout::Error)
+        end.to raise_error(Timeout::Error)
       end
     end
   end

--- a/spec/lib/fastly_nsq/message_queue/producer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/producer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MessageQueue::Producer do
           with(
             nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
             topic: topic,
-        ).at_least(:once)
+          ).at_least(:once)
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe MessageQueue::Producer do
           with(
             nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
             topic: topic,
-        ).at_least(:once)
+          ).at_least(:once)
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe MessageQueue::Producer do
 
         producer = MessageQueue::Producer.new(topic: topic)
 
-        expect{ producer.connection }.to raise_error(InvalidParameterError)
+        expect { producer.connection }.to raise_error(InvalidParameterError)
       end
     end
   end

--- a/spec/lib/fastly_nsq/message_queue/strategy_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/strategy_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Strategy do
       it 'raises with a helpful error' do
         allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return('taco')
 
-        expect{ Strategy.for_queue }.to raise_error(InvalidParameterError)
+        expect { Strategy.for_queue }.to raise_error(InvalidParameterError)
       end
     end
   end

--- a/spec/lib/fastly_nsq/rake_task_spec.rb
+++ b/spec/lib/fastly_nsq/rake_task_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe MessageQueue::RakeTask do
     context 'when multiple topics are defined' do
       it 'creates a listener for each' do
         channel = 'clown_generating_service'
-        topics = ['customer_created', 'customer_now_awesome']
+        topics = %w(customer_created customer_now_awesome)
         allow(SampleMessageProcessor).to receive(:topics).and_return(topics)
         message_queue_listener = double('listener', go: nil)
         allow(MessageQueue::Listener).to receive(:new).
@@ -105,23 +105,24 @@ RSpec.describe MessageQueue::RakeTask do
         topics = ['customer_created']
         allow(SampleMessageProcessor).to receive(:topics).and_return(topics)
 
-        expect {
+        expect do
           MessageQueue::RakeTask.new(:begin_listening, [:channel])
           Rake::Task['begin_listening'].execute
-        }.to raise_error(ArgumentError, /channel is required/)
+        end.to raise_error(ArgumentError, /channel is required/)
       end
     end
 
     context 'when MessageProcessor.topics is not defined' do
       it 'raises an error' do
         channel = 'best_server_number_1'
+        error_message = /MessageProcessor.topics is not defined/
         allow(SampleMessageProcessor).to receive(:topics).
           and_raise(NoMethodError, "undefined method `topics'")
 
-        expect {
+        expect do
           MessageQueue::RakeTask.new(:begin_listening, [:channel])
           Rake::Task['begin_listening'].execute(channel: channel)
-        }.to raise_error(ArgumentError, /MessageProcessor.topics is not defined/)
+        end.to raise_error(ArgumentError, error_message)
       end
     end
   end


### PR DESCRIPTION
# Reason for Change
- We would like to enforce style guidelines in our application programmatically.
# Changes
- Add the Rubocop gem and `rake rubocop` task.
- Import the Rubocop config file from another app.
- Fix Rubocop violations.
- Enforce Rubocop using Overcommit post-git hooks via it's gem and `.overcommit.yml` config file.
- Have Rubocop target Ruby 2.1, since that is the lowest supported version.
- Reduce branch complexity of a method
## Minor
- Resort Rake tasks to match the order in which they run.
## Risks
- None, these are development enhancements.

Done as part of this Jira but PRed separately:
https://jira.corp.fastly.com/browse/HYD-735
# Checklist

_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream
# Recommended Reviewers

@alieander, @standingwave 
