### PR TITLE
Update rake to 11.1.2

### DIFF
--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -21,14 +21,14 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_development_dependency 'awesome_print', '~> 1.6'
-  gem.add_development_dependency 'bundler', '~> 1.10'
-  gem.add_development_dependency 'bundler-audit', '~> 0.4'
+  gem.add_development_dependency 'bundler', '~> 1.11.2'
+  gem.add_development_dependency 'bundler-audit', '~> 0.5.0'
   gem.add_development_dependency 'overcommit', '~> 0.32.0'
   gem.add_development_dependency 'pry-byebug', '~> 3.3'
-  gem.add_development_dependency 'rake', '~> 10.5'
-  gem.add_development_dependency 'rdoc', '~> 4.2'
-  gem.add_development_dependency 'rspec', '~> 3.4'
-  gem.add_development_dependency 'rubocop', '~> 0.38.0'
+  gem.add_development_dependency 'rake', '~> 11.1.2'
+  gem.add_development_dependency 'rdoc', '~> 4.2.2'
+  gem.add_development_dependency 'rspec', '~> 3.4.0'
+  gem.add_development_dependency 'rubocop', '~> 0.39.0'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
 
   gem.add_dependency 'nsq-ruby', '~> 1.5.0', '>= 1.5.0'

--- a/lib/fastly_nsq/rake_task.rb
+++ b/lib/fastly_nsq/rake_task.rb
@@ -28,7 +28,7 @@ module MessageQueue
     private
 
     def add_rake_task_description_if_one_needed
-      unless ::Rake.application.last_comment
+      unless ::Rake.application.last_description
         desc 'Listen to NSQ on topic using channel'
       end
     end

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end


### PR DESCRIPTION
# Reason for Change
- Rake has deprecated the use of `last_comment` in favor of `last_description` as of 11.0. See [release notes](https://github.com/ruby/rake/blob/fdd52c75ee4ca29a12ccf23d17c1286066b63116/History.rdoc#1100--2016-03-09) for more.
# Changes
- Update `rake` to ~> 11.1.2.
- Remove our usage of last_comment in favor of last_description
# Minor
- Update `rdoc` and `rspec` to remove deprecation warnings.
- Update RuboCop also. This is a reported source of these warnings.
- Update the rest of the development dependencies, while we are at it.
# Risks
- This regards deprecation warnings, so no risk seems apparent.
# Checklist

_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream
# Recommended Reviewers

@alieander, @standingwave 
