### PR TITLE
Add SSLContext to fastly_nsq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'nsq-ruby', '~> 1.5.0', '>= 1.5.0', git: 'https://github.com/fastly/nsq-ruby.git'
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'nsq-ruby', '~> 1.5.0', '>= 1.5.0', git: 'https://github.com/fastly/nsq-ruby.git'
-
 gemspec

--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.4.0'
   gem.add_development_dependency 'rubocop', '~> 0.39.0'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
+
+  gem.add_dependency 'nsq-ruby', '~> 1.6.0', '>= 1.6.0'
 end

--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -30,6 +30,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.4.0'
   gem.add_development_dependency 'rubocop', '~> 0.39.0'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
-
-  gem.add_dependency 'nsq-ruby', '~> 1.5.0', '>= 1.5.0'
 end

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -22,7 +22,7 @@ module FakeMessageQueue
   end
 
   class Producer
-    def initialize(nsqd:, topic:)
+    def initialize(nsqd:, topic:, ssl_context: nil)
     end
 
     def write(string)
@@ -44,7 +44,7 @@ module FakeMessageQueue
   class Consumer
     SECONDS_BETWEEN_QUEUE_CHECKS = 0.5
 
-    def initialize(nsqlookupd:, topic:, channel:)
+    def initialize(nsqlookupd:, topic:, channel:, ssl_context: nil)
     end
 
     def pop

--- a/lib/fastly_nsq/message_queue.rb
+++ b/lib/fastly_nsq/message_queue.rb
@@ -4,6 +4,7 @@ require_relative 'message_queue/listener'
 require_relative 'message_queue/producer'
 require_relative 'message_queue/consumer'
 require_relative 'message_queue/strategy'
+require_relative 'ssl_context'
 
 module MessageQueue
   FALSY_VALUES = [false, 0, '0', 'false', 'FALSE', 'off', 'OFF', nil].freeze

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -2,9 +2,10 @@ class InvalidParameterError < StandardError; end
 
 module MessageQueue
   class Consumer
-    def initialize(topic:, channel:)
+    def initialize(topic:, channel:, ssl_context: nil)
       @topic = topic
       @channel = channel
+      @ssl_context = SSLContext.new(ssl_context)
     end
 
     def connection
@@ -17,7 +18,7 @@ module MessageQueue
 
     private
 
-    attr_reader :channel, :topic
+    attr_reader :channel, :topic, :ssl_context
 
     def consumer
       Strategy.for_queue::Consumer
@@ -28,6 +29,7 @@ module MessageQueue
         nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
         topic: topic,
         channel: channel,
+        ssl_context: ssl_context.to_h,
       }
     end
   end

--- a/lib/fastly_nsq/message_queue/producer.rb
+++ b/lib/fastly_nsq/message_queue/producer.rb
@@ -2,8 +2,9 @@ class InvalidParameterError < StandardError; end
 
 module MessageQueue
   class Producer
-    def initialize(topic:)
+    def initialize(topic:, ssl_context: nil)
       @topic = topic
+      @ssl_context = SSLContext.new(ssl_context)
     end
 
     def connection
@@ -16,7 +17,7 @@ module MessageQueue
 
     private
 
-    attr_reader :topic
+    attr_reader :topic, :ssl_context
 
     def producer
       Strategy.for_queue::Producer
@@ -26,6 +27,7 @@ module MessageQueue
       {
         nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
         topic: topic,
+        ssl_context: ssl_context.to_h,
       }
     end
   end

--- a/lib/fastly_nsq/ssl_context.rb
+++ b/lib/fastly_nsq/ssl_context.rb
@@ -1,0 +1,44 @@
+class SSLContext
+  def initialize(context = nil)
+    @context = context || {}
+  end
+
+  def to_h
+    merge_contexts
+    if empty_context?
+      nil
+    else
+      @context
+    end
+  end
+
+  private
+
+  def env_key
+    ENV.fetch('NSQ_SSL_KEY', nil)
+  end
+
+  def env_certificate
+    ENV.fetch('NSQ_SSL_CERTIFICATE', nil)
+  end
+
+  def env_ca_certificate
+    ENV.fetch('NSQ_SSL_CA_CERTIFICATE', nil)
+  end
+
+  def env_default_hash
+    {
+      key: env_key,
+      certificate: env_certificate,
+      ca_certificate: env_ca_certificate,
+    }
+  end
+
+  def merge_contexts
+    @context = env_default_hash.merge(@context)
+  end
+
+  def empty_context?
+    @context.all? { |_key, value| value.nil? }
+  end
+end

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe MessageQueue::Consumer do
             nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
             topic: topic,
             channel: channel,
+            ssl_context: nil,
           ).at_least(:once)
       end
     end
@@ -32,6 +33,7 @@ RSpec.describe MessageQueue::Consumer do
             nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
             topic: topic,
             channel: channel,
+            ssl_context: nil,
           ).at_least(:once)
       end
     end

--- a/spec/lib/fastly_nsq/message_queue/producer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/producer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe MessageQueue::Producer do
           with(
             nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
             topic: topic,
+            ssl_context: nil,
           ).at_least(:once)
       end
     end
@@ -28,6 +29,7 @@ RSpec.describe MessageQueue::Producer do
           with(
             nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
             topic: topic,
+            ssl_context: nil,
           ).at_least(:once)
       end
     end

--- a/spec/lib/fastly_nsq/ssl_context_spec.rb
+++ b/spec/lib/fastly_nsq/ssl_context_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe SSLContext do
+  describe 'when SSL ENV variables are not set' do
+    describe '.to_h' do
+      it 'returns nil when initialized without parameters' do
+        context = SSLContext.new
+
+        expect(context.to_h).to be_nil
+      end
+
+      it 'returns an equivalent hash when all variables are defined' do
+        ssl_context_hash = {
+          key: 'key',
+          certificate: 'certificate',
+          ca_certificate: 'ca_certificate',
+        }
+        context = SSLContext.new(ssl_context_hash)
+
+        expect(context.to_h).to eq(ssl_context_hash)
+      end
+
+      it 'does not add keys with nil values' do
+        ssl_context_hash = {
+          key: 'key',
+          certificate: 'certificate',
+        }
+        context = SSLContext.new(ssl_context_hash)
+        ca_certificate = context.to_h[:ca_certificate]
+
+        expect(ca_certificate).to be_nil
+      end
+    end
+  end
+
+  describe 'when SSL ENV variables are set' do
+    before do
+      ENV['NSQ_SSL_KEY'] = '/some/key'
+      ENV['NSQ_SSL_CERTIFICATE'] = '/some/certificate'
+      ENV['NSQ_SSL_CA_CERTIFICATE'] = '/some/ca_certificate'
+    end
+
+    after do
+      ENV['NSQ_SSL_KEY'] = nil
+      ENV['NSQ_SSL_CERTIFICATE'] = nil
+      ENV['NSQ_SSL_CA_CERTIFICATE'] = nil
+    end
+
+    describe '.to_h' do
+      it 'returns a hash of the env variables when no parameters are passed' do
+        expected_hash = {
+          key: ENV['NSQ_SSL_KEY'],
+          certificate: ENV['NSQ_SSL_CERTIFICATE'],
+          ca_certificate: ENV['NSQ_SSL_CA_CERTIFICATE'],
+        }
+        context = SSLContext.new
+
+        expect(context.to_h).to eq(expected_hash)
+      end
+
+      it 'merges passed parameters and env variables' do
+        passed_certificate = '/passed/certificate'
+        expected_hash = {
+          key: ENV['NSQ_SSL_KEY'],
+          certificate: passed_certificate,
+          ca_certificate: ENV['NSQ_SSL_CA_CERTIFICATE'],
+        }
+        context = SSLContext.new(certificate: passed_certificate)
+
+        expect(context.to_h).to eq(expected_hash)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Reason for change

We would like to be able to use TLS/SSL.
This allows us to pass a SSLContext thru the producer or consumer to the
nsq-ruby gem which will then use that information to encrypt communitcations.
We would also like for this to be easily setup via ENV variables.
# Changes
- Add an SSLContext class with tests
- Use this class in Consumer and Producer
- Allow consumer and producer to accept a passed in hash ssl_context
- Forward this SSLContext to the underlying Strategy
- Bump nsq-ruby gem version to 1.6.0
