### PR TITLE
Should Listener#consumer -> Consumer, or Consumer#connection?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 cache: bundler
+before_install:
+  - "gem install bundler -v '1.11.2'"
 rvm:
   - 2.1.8
   - 2.2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-before_install: gem install bundler -v '1.11.2'
 rvm:
   - 2.1.8
   - 2.2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
-before_install:
-  - "gem install bundler -v '1.11.2'"
+before_install: gem install bundler -v '1.11.2'
 rvm:
   - 2.1.8
   - 2.2.4

--- a/README.md
+++ b/README.md
@@ -1,22 +1,14 @@
 # fastly_nsq [![Build Status](https://travis-ci.org/fastly/fastly_nsq.svg?branch=master)](https://travis-ci.org/fastly/fastly_nsq)
 
-*NOTE: This is a point-release
-which is not yet suitable for production.
-Use at your own peril.*
+*NOTE: This is a point-release which is not yet suitable for production. Use at your own peril.*
 
-NSQ adapter and testing objects
-for using the NSQ messaging system
-in your Ruby project.
+NSQ adapter and testing objects for using the NSQ messaging system in your Ruby project.
 
-This library is intended
-to facilitate publishing and consuming
-messages on an NSQ messaging queue.
+This library is intended to facilitate publishing and consuming messages on an NSQ messaging queue.
 
-We also include fakes
-to make testing easier.
+We also include fakes to make testing easier.
 
-This library is dependent
-on the [`nsq-ruby`] gem.
+This library is dependent on the [`nsq-ruby`] gem.
 
 [`nsq-ruby`]: https://github.com/wistia/nsq-ruby
 
@@ -27,28 +19,18 @@ Please use [GitHub Issues] to report bugs.
 
 ## Install
 
-`fastly_nsq` is a Ruby Gem
-tested against Rails `>= 4.2`
-and Ruby `>= 2.3.0`.
+`fastly_nsq` is a Ruby Gem tested against Rails `>= 4.2` and Ruby `>= 2.3.0`.
 
-To get started,
-add `fastly_nsq` to your `Gemfile`
-and `bundle install`.
+To get started, add `fastly_nsq` to your `Gemfile` and `bundle install`.
 
 ## Usage
-
-*IMPORTANT NOTE:* You must create your own `MessageProcessor` class
-for this gem to work in your application.
+*IMPORTANT NOTE:* You must create your own `MessageProcessor` class for this gem to work in your application.
 
 See more information below.
 
 ### `MessageQueue::Producer`
 
-This is a class
-which provides an adapter to the
-fake and real NSQ producers.
-These are used to
-write messages onto the queue:
+This is a class which provides an adapter to the fake and real NSQ producers. These are used to write messages onto the queue:
 
 ```ruby
 message_data = {
@@ -64,10 +46,8 @@ producer = MessageQueue::Producer.new(
 
 producer.write(message_data.to_json)
 ```
-The mock/real strategy used
-can be switched
-by adding an environment variable
-to your application:
+
+The mock/real strategy used can be switched by adding an environment variable to your application:
 
 ```ruby
 # for the fake
@@ -78,11 +58,8 @@ ENV['FAKE_QUEUE'] = false
 ```
 
 ### `MessageQueue::Consumer`
-This is a class
-which provides an adapter to the
-fake and real NSQ consumers.
-These are used to
-read messages off of the queue:
+
+This is a class which provides an adapter to the fake and real NSQ consumers. These are used to read messages off of the queue:
 
 ```ruby
 consumer = MessageQueue::Consumer.new(
@@ -98,10 +75,7 @@ consumer.size #=> 0
 consumer.terminate
 ```
 
-As above,
-the mock/real strategy used
-can be switched by setting the
-`FAKE_QUEUE` environment variable appropriately.
+As above, the mock/real strategy used can be switched by setting the `FAKE_QUEUE` environment variable appropriately.
 
 ### `MessageQueue::Listener`
 
@@ -114,10 +88,7 @@ channel = 'my_consuming_service'
 MessageQueue::Listener.new(topic: topic, channel: channel).process_next_message
 ```
 
-This will pop the next message
-off of the queue
-and send the JSON text body
-to `MessageProcessor.new(message_body: message_body, topic: topic).go`.
+This will pop the next message off of the queue and send the JSON text body to `MessageProcessor.new(message_body: message_body, topic: topic).go`.
 
 To initiate a blocking loop to process messages continuously:
 
@@ -128,26 +99,15 @@ channel = 'my_consuming_service'
 MessageQueue::Listener.new(topic: topic, channel: channel).go
 ```
 
-This will block until
-there is a new message on the queue,
-      pop the next message
-      off of the queue
-      and send it to `MessageProcessor.new(message_body).go`.
+This will block until there is a new message on the queue, pop the next message off of the queue and send it to `MessageProcessor.new(message_body).go`.
 
 ### `MessageQueue::RakeTask`
 
-To help facilitate running the `MessageQueue::Listener` in a blocking fashion
-outside your application, a simple `RakeTask` is provided.
+To help facilitate running the `MessageQueue::Listener` in a blocking fashion outside your application, a simple `RakeTask` is provided.
 
-NOTE: The rake task expects a
-`MessageProcessor.topics` method,
-which must return an array of strings
-defining the topics to which
-we would like to listen and process messages.
+NOTE: The rake task expects a `MessageProcessor.topics` method, which must return an array of strings defining the topics to which we would like to listen and process messages.
 
-The task will listen
-to all specified topics,
-each in a separate thread.
+The task will listen to all specified topics, each in a separate thread.
 
 This task can be added into your `Rakefile` in one of two ways:
 
@@ -173,34 +133,21 @@ MessageQueue::RakeTask.new(:listen_task, [:channel])
 `rake listen_task['my_channel']`
 ```
 
-Both methods can be used at the same time with the passed in values taking
-priority over block assigned values
+Both methods can be used at the same time with the passed in values taking priority over block assigned values
 
-See the [`Rakefile`](examples/Rakefile) file
-for more detail.
+See the [`Rakefile`](examples/Rakefile) file for more detail.
 
 ### Real vs. Fake
+The real strategy creates a connection to `nsq-ruby`'s `Nsq::Producer` and `Nsq::Consumer` classes.
 
-The real strategy
-creates a connection
-to `nsq-ruby`'s
-`Nsq::Producer` and `Nsq::Consumer` classes.
-
-The fake strategy
-mocks the connection
-to NSQ for testing purposes.
-It adheres to the same API
-as the real adapter.
+The fake strategy mocks the connection to NSQ for testing purposes. It adheres to the same API as the real adapter.
 
 
 ## Configuration
 
 ### Processing Messages
 
-This gem expects you to create a
-new class called `MessageProcessor`
-which will process messages
-once they are consumed off of the queue topic.
+This gem expects you to create a new class called `MessageProcessor` which will process messages once they are consumed off of the queue topic.
 
 This class needs to adhere to the following API:
 
@@ -225,14 +172,9 @@ end
 
 ### Environment Variables
 
-The URLs for the various
-NSQ endpoints are expected
-in `ENV` variables.
+The URLs for the various NSQ endpoints are expected in `ENV` variables.
 
-Below are the required variables
-and sample values for using
-stock NSQ on OS X,
-installed via Homebrew:
+Below are the required variables and sample values for using stock NSQ on OS X, installed via Homebrew:
 
 ```shell
 BROADCAST_ADDRESS='127.0.0.1'
@@ -242,36 +184,21 @@ NSQLOOKUPD_TCP_ADDRESS='127.0.0.1:4160'
 NSQLOOKUPD_HTTP_ADDRESS='127.0.0.1:4161'
 ```
 
-See the [`.sample.env`](examples/.sample.env) file
-for more detail.
+See the [`.sample.env`](examples/.sample.env) file for more detail.
 
 ### Testing Against the Fake
+In the gem's test suite, the fake message queue is used.
 
-In the gem's test suite,
-the fake message queue is used.
+If you would like to force use of the real NSQ adapter, ensure `FAKE_QUEUE` is set to `false`.
 
-If you would like to force
-use of the real NSQ adapter,
-ensure `FAKE_QUEUE` is set to `false`.
-
-When you are developing your application,
-it is recommended to
-start by using the fake queue:
+When you are developing your application, it is recommended to start by using the fake queue:
 
 ```shell
 FAKE_QUEUE=true
 ```
+Also be sure call `FakeMessageQueue.reset!` before each test in your app to ensure there are no leftover messages.
 
-Also be sure call
-`FakeMessageQueue.reset!`
-before each test in your app to ensure
-there are no leftover messages.
-
-Also note that during gem tests,
-we are aliasing `MessageProcessor` to `SampleMessageProcessor`.
-You can also refer to the latter
-as an example of how
-you might write your own processor.
+Also note that during gem tests, we are aliasing `MessageProcessor` to `SampleMessageProcessor`. You can also refer to the latter as an example of how you might write your own processor.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # fastly_nsq [![Build Status](https://travis-ci.org/fastly/fastly_nsq.svg?branch=master)](https://travis-ci.org/fastly/fastly_nsq)
 
-*NOTE: This is a point-release which is not yet suitable for production. Use at your own peril.*
+*NOTE: This is a point-release
+which is not yet suitable for production.
+Use at your own peril.*
 
-NSQ adapter and testing objects for using the NSQ messaging system in your Ruby project.
+NSQ adapter and testing objects
+for using the NSQ messaging system
+in your Ruby project.
 
-This library is intended to facilitate publishing and consuming messages on an NSQ messaging queue.
+This library is intended
+to facilitate publishing and consuming
+messages on an NSQ messaging queue.
 
-We also include fakes to make testing easier.
+We also include fakes
+to make testing easier.
 
-This library is dependent on the [`nsq-ruby`] gem.
+This library is dependent
+on the [`nsq-ruby`] gem.
 
 [`nsq-ruby`]: https://github.com/wistia/nsq-ruby
 
@@ -19,18 +27,28 @@ Please use [GitHub Issues] to report bugs.
 
 ## Install
 
-`fastly_nsq` is a Ruby Gem tested against Rails `>= 4.2` and Ruby `>= 2.1.8`.
+`fastly_nsq` is a Ruby Gem
+tested against Rails `>= 4.2`
+and Ruby `>= 2.1.8`.
 
-To get started, add `fastly_nsq` to your `Gemfile` and `bundle install`.
+To get started,
+add `fastly_nsq` to your `Gemfile`
+and `bundle install`.
 
 ## Usage
-*IMPORTANT NOTE:* You must create your own `MessageProcessor` class for this gem to work in your application.
+
+*IMPORTANT NOTE:* You must create your own `MessageProcessor` class
+for this gem to work in your application.
 
 See more information below.
 
 ### `MessageQueue::Producer`
 
-This is a class which provides an adapter to the fake and real NSQ producers. These are used to write messages onto the queue:
+This is a class
+which provides an adapter to the
+fake and real NSQ producers.
+These are used to
+write messages onto the queue:
 
 ```ruby
 message_data = {
@@ -46,8 +64,10 @@ producer = MessageQueue::Producer.new(
 
 producer.write(message_data.to_json)
 ```
-
-The mock/real strategy used can be switched by adding an environment variable to your application:
+The mock/real strategy used
+can be switched
+by adding an environment variable
+to your application:
 
 ```ruby
 # for the fake
@@ -58,8 +78,11 @@ ENV['FAKE_QUEUE'] = false
 ```
 
 ### `MessageQueue::Consumer`
-
-This is a class which provides an adapter to the fake and real NSQ consumers. These are used to read messages off of the queue:
+This is a class
+which provides an adapter to the
+fake and real NSQ consumers.
+These are used to
+read messages off of the queue:
 
 ```ruby
 consumer = MessageQueue::Consumer.new(
@@ -75,7 +98,10 @@ consumer.size #=> 0
 consumer.terminate
 ```
 
-As above, the mock/real strategy used can be switched by setting the `FAKE_QUEUE` environment variable appropriately.
+As above,
+the mock/real strategy used
+can be switched by setting the
+`FAKE_QUEUE` environment variable appropriately.
 
 ### `MessageQueue::Listener`
 
@@ -88,7 +114,10 @@ channel = 'my_consuming_service'
 MessageQueue::Listener.new(topic: topic, channel: channel).process_next_message
 ```
 
-This will pop the next message off of the queue and send the JSON text body to `MessageProcessor.new(message_body: message_body, topic: topic).go`.
+This will pop the next message
+off of the queue
+and send the JSON text body
+to `MessageProcessor.new(message_body: message_body, topic: topic).go`.
 
 To initiate a blocking loop to process messages continuously:
 
@@ -99,15 +128,26 @@ channel = 'my_consuming_service'
 MessageQueue::Listener.new(topic: topic, channel: channel).go
 ```
 
-This will block until there is a new message on the queue, pop the next message off of the queue and send it to `MessageProcessor.new(message_body).go`.
+This will block until
+there is a new message on the queue,
+      pop the next message
+      off of the queue
+      and send it to `MessageProcessor.new(message_body).go`.
 
 ### `MessageQueue::RakeTask`
 
-To help facilitate running the `MessageQueue::Listener` in a blocking fashion outside your application, a simple `RakeTask` is provided.
+To help facilitate running the `MessageQueue::Listener` in a blocking fashion
+outside your application, a simple `RakeTask` is provided.
 
-NOTE: The rake task expects a `MessageProcessor.topics` method, which must return an array of strings defining the topics to which we would like to listen and process messages.
+NOTE: The rake task expects a
+`MessageProcessor.topics` method,
+which must return an array of strings
+defining the topics to which
+we would like to listen and process messages.
 
-The task will listen to all specified topics, each in a separate thread.
+The task will listen
+to all specified topics,
+each in a separate thread.
 
 This task can be added into your `Rakefile` in one of two ways:
 
@@ -133,21 +173,34 @@ MessageQueue::RakeTask.new(:listen_task, [:channel])
 `rake listen_task['my_channel']`
 ```
 
-Both methods can be used at the same time with the passed in values taking priority over block assigned values
+Both methods can be used at the same time with the passed in values taking
+priority over block assigned values
 
-See the [`Rakefile`](examples/Rakefile) file for more detail.
+See the [`Rakefile`](examples/Rakefile) file
+for more detail.
 
 ### Real vs. Fake
-The real strategy creates a connection to `nsq-ruby`'s `Nsq::Producer` and `Nsq::Consumer` classes.
 
-The fake strategy mocks the connection to NSQ for testing purposes. It adheres to the same API as the real adapter.
+The real strategy
+creates a connection
+to `nsq-ruby`'s
+`Nsq::Producer` and `Nsq::Consumer` classes.
+
+The fake strategy
+mocks the connection
+to NSQ for testing purposes.
+It adheres to the same API
+as the real adapter.
 
 
 ## Configuration
 
 ### Processing Messages
 
-This gem expects you to create a new class called `MessageProcessor` which will process messages once they are consumed off of the queue topic.
+This gem expects you to create a
+new class called `MessageProcessor`
+which will process messages
+once they are consumed off of the queue topic.
 
 This class needs to adhere to the following API:
 
@@ -172,9 +225,14 @@ end
 
 ### Environment Variables
 
-The URLs for the various NSQ endpoints are expected in `ENV` variables.
+The URLs for the various
+NSQ endpoints are expected
+in `ENV` variables.
 
-Below are the required variables and sample values for using stock NSQ on OS X, installed via Homebrew:
+Below are the required variables
+and sample values for using
+stock NSQ on OS X,
+installed via Homebrew:
 
 ```shell
 BROADCAST_ADDRESS='127.0.0.1'
@@ -184,21 +242,36 @@ NSQLOOKUPD_TCP_ADDRESS='127.0.0.1:4160'
 NSQLOOKUPD_HTTP_ADDRESS='127.0.0.1:4161'
 ```
 
-See the [`.sample.env`](examples/.sample.env) file for more detail.
+See the [`.sample.env`](examples/.sample.env) file
+for more detail.
 
 ### Testing Against the Fake
-In the gem's test suite, the fake message queue is used.
 
-If you would like to force use of the real NSQ adapter, ensure `FAKE_QUEUE` is set to `false`.
+In the gem's test suite,
+the fake message queue is used.
 
-When you are developing your application, it is recommended to start by using the fake queue:
+If you would like to force
+use of the real NSQ adapter,
+ensure `FAKE_QUEUE` is set to `false`.
+
+When you are developing your application,
+it is recommended to
+start by using the fake queue:
 
 ```shell
 FAKE_QUEUE=true
 ```
-Also be sure call `FakeMessageQueue.reset!` before each test in your app to ensure there are no leftover messages.
 
-Also note that during gem tests, we are aliasing `MessageProcessor` to `SampleMessageProcessor`. You can also refer to the latter as an example of how you might write your own processor.
+Also be sure call
+`FakeMessageQueue.reset!`
+before each test in your app to ensure
+there are no leftover messages.
+
+Also note that during gem tests,
+we are aliasing `MessageProcessor` to `SampleMessageProcessor`.
+You can also refer to the latter
+as an example of how
+you might write your own processor.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This is a class which provides an adapter to the fake and real NSQ consumers. Th
 consumer = MessageQueue::Consumer.new(
   topic: 'topic',
   channel: 'channel'
-).connection
+)
 
 consumer.size #=> 1
 message = consumer.pop

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please use [GitHub Issues] to report bugs.
 
 ## Install
 
-`fastly_nsq` is a Ruby Gem tested against Rails `>= 4.2` and Ruby `>= 2.3.0`.
+`fastly_nsq` is a Ruby Gem tested against Rails `>= 4.2` and Ruby `>= 2.1.8`.
 
 To get started, add `fastly_nsq` to your `Gemfile` and `bundle install`.
 

--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_development_dependency 'awesome_print', '~> 1.6'
-  gem.add_development_dependency 'bundler', '~> 1.11.2'
+  gem.add_development_dependency 'bundler', '~> 1.12'
   gem.add_development_dependency 'bundler-audit', '~> 0.5.0'
   gem.add_development_dependency 'overcommit', '~> 0.32.0'
   gem.add_development_dependency 'pry-byebug', '~> 3.3'

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -44,7 +44,7 @@ module FakeMessageQueue
   class Consumer
     SECONDS_BETWEEN_QUEUE_CHECKS = 0.5
 
-    def initialize(nsqlookupd:, topic:, channel:, ssl_context: nil)
+    def initialize(nsqlookupd: nil, topic:, channel:, ssl_context: nil)
     end
 
     def pop

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -55,7 +55,7 @@ module FakeMessageQueue
     def initialize(nsqlookupd: nil, topic:, channel:, ssl_context: nil)
     end
 
-    def pop(delay=FakeMessageQueue.delay)
+    def pop(delay = FakeMessageQueue.delay)
       message = nil
 
       until message

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -66,6 +66,10 @@ module FakeMessageQueue
       message
     end
 
+    def pop_without_blocking
+      queue.pop
+    end
+
     def size
       queue.size
     end

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -1,5 +1,6 @@
 module FakeMessageQueue
   @@logger = Logger.new(nil)
+  @@delay  = 0.5
 
   def self.queue
     @@queue
@@ -19,6 +20,14 @@ module FakeMessageQueue
 
   def self.logger
     @@logger
+  end
+
+  def self.delay
+    @@delay
+  end
+
+  def self.delay=(delay)
+    @@delay = delay
   end
 
   class Producer
@@ -42,17 +51,15 @@ module FakeMessageQueue
   end
 
   class Consumer
-    SECONDS_BETWEEN_QUEUE_CHECKS = 0.5
-
     def initialize(nsqlookupd: nil, topic:, channel:, ssl_context: nil)
     end
 
-    def pop
+    def pop(delay=FakeMessageQueue.delay)
       message = nil
 
       until message
         message = queue.pop
-        sleep SECONDS_BETWEEN_QUEUE_CHECKS
+        sleep delay
       end
 
       message

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -1,6 +1,7 @@
 module FakeMessageQueue
   @@logger = Logger.new(nil)
   @@delay  = 0.5
+  @@queue  = []
 
   def self.queue
     @@queue

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -5,7 +5,7 @@ class InvalidParameterError < StandardError; end
 module MessageQueue
   class Consumer
     extend Forwardable
-    def_delegator :connection, :pop, :terminate
+    def_delegator :connection, :pop, :pop_without_blocking, :terminate
 
     def initialize(topic:, channel:, ssl_context: nil)
       @topic = topic

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -12,6 +12,10 @@ module MessageQueue
       connection.terminate
     end
 
+    def connect
+      !!connection
+    end
+
     private
 
     attr_reader :channel, :topic, :ssl_context

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -5,7 +5,7 @@ class InvalidParameterError < StandardError; end
 module MessageQueue
   class Consumer
     extend Forwardable
-    def_delegator :connection, :pop
+    def_delegator :connection, :pop, :terminate
 
     def initialize(topic:, channel:, ssl_context: nil)
       @topic = topic
@@ -13,21 +13,12 @@ module MessageQueue
       @ssl_context = SSLContext.new(ssl_context)
     end
 
-    def terminate
-      connection.terminate
-    end
-
-    def connect
-      @connection = nil
-      !!connection
-    end
-
     private
 
     attr_reader :channel, :topic, :ssl_context
 
     def connection
-      @connection ||= Strategy.for_queue::Consumer.new(params)
+      Strategy.for_queue::Consumer.new(params)
     end
 
     def params

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -1,7 +1,12 @@
+require 'forwardable'
+
 class InvalidParameterError < StandardError; end
 
 module MessageQueue
   class Consumer
+    extend Forwardable
+    def_delegator :connection, :pop
+
     def initialize(topic:, channel:, ssl_context: nil)
       @topic = topic
       @channel = channel

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -8,17 +8,17 @@ module MessageQueue
       @ssl_context = SSLContext.new(ssl_context)
     end
 
-    def connection
-      @connection ||= consumer.new(params)
-    end
-
     def terminate
-      @connection.terminate
+      connection.terminate
     end
 
     private
 
     attr_reader :channel, :topic, :ssl_context
+
+    def connection
+      @connection ||= consumer.new(params)
+    end
 
     def consumer
       Strategy.for_queue::Consumer

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -22,11 +22,7 @@ module MessageQueue
     attr_reader :channel, :topic, :ssl_context
 
     def connection
-      @connection ||= consumer.new(params)
-    end
-
-    def consumer
-      Strategy.for_queue::Consumer
+      @connection ||= Strategy.for_queue::Consumer.new(params)
     end
 
     def params

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -13,6 +13,7 @@ module MessageQueue
     end
 
     def connect
+      @connection = nil
       !!connection
     end
 

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -5,7 +5,9 @@ class InvalidParameterError < StandardError; end
 module MessageQueue
   class Consumer
     extend Forwardable
-    def_delegator :connection, :pop, :pop_without_blocking, :terminate
+    def_delegator :connection, :pop
+    def_delegator :connection, :pop_without_blocking
+    def_delegator :connection, :terminate
 
     def initialize(topic:, channel:, ssl_context: nil)
       @topic = topic

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -7,6 +7,7 @@ module MessageQueue
     extend Forwardable
     def_delegator :connection, :pop
     def_delegator :connection, :pop_without_blocking
+    def_delegator :connection, :size
     def_delegator :connection, :terminate
 
     def initialize(topic:, channel:, ssl_context: nil)

--- a/lib/fastly_nsq/message_queue/listener.rb
+++ b/lib/fastly_nsq/message_queue/listener.rb
@@ -1,8 +1,10 @@
 module MessageQueue
   class Listener
-    def initialize(topic:, channel:)
-      @topic = topic
-      @channel = channel
+    def initialize(topic:, channel:, processor: nil, consumer: nil)
+      @topic     = topic
+      @channel   = channel
+      @processor = processor || DEFAULT_PROCESSOR
+      @consumer  = consumer
     end
 
     def go
@@ -26,11 +28,12 @@ module MessageQueue
 
     private
 
-    attr_reader :channel, :topic
+    attr_reader :channel, :topic, :processor
+    DEFAULT_PROCESSOR = ->(body, topic) { MessageProcessor.new(message_body: body, topic: topic).go }
 
     def process_one_message
       message = consumer.pop
-      MessageProcessor.new(message_body: message.body, topic: topic).go
+      processor.call(message.body, topic)
       message.finish
     end
 

--- a/lib/fastly_nsq/message_queue/listener.rb
+++ b/lib/fastly_nsq/message_queue/listener.rb
@@ -4,7 +4,7 @@ module MessageQueue
       @topic     = topic
       @channel   = channel
       @processor = processor || DEFAULT_PROCESSOR
-      @consumer  = consumer
+      @consumer  = consumer  || MessageQueue::Consumer.new(consumer_params)
     end
 
     def go
@@ -28,17 +28,13 @@ module MessageQueue
 
     private
 
-    attr_reader :channel, :topic, :processor
+    attr_reader :channel, :topic, :processor, :consumer
     DEFAULT_PROCESSOR = ->(body, topic) { MessageProcessor.new(message_body: body, topic: topic).go }
 
     def process_one_message
       message = consumer.pop
       processor.call(message.body, topic)
       message.finish
-    end
-
-    def consumer
-      @consumer ||= MessageQueue::Consumer.new(consumer_params)
     end
 
     def consumer_params

--- a/lib/fastly_nsq/message_queue/listener.rb
+++ b/lib/fastly_nsq/message_queue/listener.rb
@@ -35,7 +35,7 @@ module MessageQueue
     end
 
     def consumer
-      @consumer ||= MessageQueue::Consumer.new(consumer_params).connection
+      @consumer ||= MessageQueue::Consumer.new(consumer_params)
     end
 
     def consumer_params

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe FakeMessageQueue::Message do
 end
 
 RSpec.describe FakeMessageQueue::Consumer do
-  let(:topic)   { 'death_star' }
-  let(:channel) { 'star_killer_base' }
+  let(:topic)    { 'death_star' }
+  let(:channel)  { 'star_killer_base' }
   let(:consumer) { FakeMessageQueue::Consumer.new topic: topic, channel: channel }
 
   after do

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -88,6 +88,9 @@ RSpec.describe FakeMessageQueue::Message do
 end
 
 RSpec.describe FakeMessageQueue::Consumer do
+  let(:topic)   { 'death_star' }
+  let(:channel) { 'star_killer_base' }
+
   after do
     FakeMessageQueue.reset!
   end
@@ -95,8 +98,6 @@ RSpec.describe FakeMessageQueue::Consumer do
   describe '#size' do
     it 'tells you how many messages are in the queue' do
       FakeMessageQueue.queue = ['hello']
-      topic = 'death_star'
-      channel = 'star_killer_base'
 
       consumer = FakeMessageQueue::Consumer.new(
         nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
@@ -114,8 +115,6 @@ RSpec.describe FakeMessageQueue::Consumer do
       it 'returns the last message off of the queue' do
         message = FakeMessageQueue::Message.new('hello')
         FakeMessageQueue.queue = [message]
-        topic = 'death_star'
-        channel = 'star_killer_base'
 
         consumer = FakeMessageQueue::Consumer.new(
           nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
@@ -131,8 +130,6 @@ RSpec.describe FakeMessageQueue::Consumer do
     context 'when there no message on the queue' do
       it 'blocks for longer than the queue check cycle' do
         FakeMessageQueue.queue = []
-        topic = 'death_star'
-        channel = 'star_killer_base'
         FakeMessageQueue.delay = 0.1
         delay = FakeMessageQueue.delay + 0.1
 

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -133,7 +133,8 @@ RSpec.describe FakeMessageQueue::Consumer do
         FakeMessageQueue.queue = []
         topic = 'death_star'
         channel = 'star_killer_base'
-        delay = FakeMessageQueue::Consumer::SECONDS_BETWEEN_QUEUE_CHECKS + 0.1
+        FakeMessageQueue.delay = 0.1
+        delay = FakeMessageQueue.delay + 0.1
 
         consumer = FakeMessageQueue::Consumer.new(
           nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -90,61 +90,53 @@ end
 RSpec.describe FakeMessageQueue::Consumer do
   let(:topic)   { 'death_star' }
   let(:channel) { 'star_killer_base' }
+  let(:consumer) { FakeMessageQueue::Consumer.new topic: topic, channel: channel }
 
   after do
     FakeMessageQueue.reset!
   end
 
-  describe '#size' do
-    it 'tells you how many messages are in the queue' do
-      FakeMessageQueue.queue = ['hello']
+  describe 'when there are no messages on the queue' do
+    it 'tells you there are 0 messages in the queue' do
+      expect(consumer.size).to eq 0
+    end
 
-      consumer = FakeMessageQueue::Consumer.new(
-        nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
-        topic: topic,
-        channel: channel,
-      )
-      queue_size = consumer.size
+    it 'blocks forever (until timeout) from #pop' do
+      FakeMessageQueue.delay = 0.1
+      delay = FakeMessageQueue.delay + 0.1
 
-      expect(queue_size).to eq 1
+      expect do
+        Timeout.timeout(delay) do
+          consumer.pop
+        end
+      end.to raise_error(Timeout::Error)
+    end
+
+    it 'returns nil from #pop_without_blocking' do
+      popped_message = consumer.pop_without_blocking
+
+      expect(popped_message).to be_nil
     end
   end
 
-  describe '#pop' do
-    context 'when there is a message on the queue' do
-      it 'returns the last message off of the queue' do
-        message = FakeMessageQueue::Message.new('hello')
-        FakeMessageQueue.queue = [message]
+  describe 'when there is a message on the queue' do
+    let(:message) { FakeMessageQueue::Message.new 'hello' }
+    before { FakeMessageQueue.queue = [message] }
 
-        consumer = FakeMessageQueue::Consumer.new(
-          nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
-          topic: topic,
-          channel: channel,
-        )
-        popped_message = consumer.pop
-
-        expect(popped_message).to eq message
-      end
+    it 'tells you there are messages in the queue' do
+      expect(consumer.size).to eq 1
     end
 
-    context 'when there no message on the queue' do
-      it 'blocks for longer than the queue check cycle' do
-        FakeMessageQueue.queue = []
-        FakeMessageQueue.delay = 0.1
-        delay = FakeMessageQueue.delay + 0.1
+    it 'returns a message immediately from #pop' do
+      popped_message = consumer.pop
 
-        consumer = FakeMessageQueue::Consumer.new(
-          nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
-          topic: topic,
-          channel: channel,
-        )
+      expect(popped_message).to eq message
+    end
 
-        expect do
-          Timeout.timeout(delay) do
-            consumer.pop
-          end
-        end.to raise_error(Timeout::Error)
-      end
+    it 'returns a message immediately from #pop_without_blocking' do
+      popped_message = consumer.pop_without_blocking
+
+      expect(popped_message).to eq message
     end
   end
 

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe MessageQueue::Consumer do
   describe 'when the ENV is set incorrectly' do
     it 'raises with a helpful error' do
       allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return('taco')
-      
+
       expect { consumer.connect }.to raise_error(InvalidParameterError)
     end
   end
@@ -53,6 +53,7 @@ RSpec.describe MessageQueue::Consumer do
         fake_consumer = double('Consumer', connection: nil, terminate: nil)
         allow(Nsq::Consumer).to receive(:new).and_return(fake_consumer)
 
+        consumer.connect
         consumer.terminate
 
         expect(fake_consumer).to have_received(:terminate)
@@ -64,6 +65,7 @@ RSpec.describe MessageQueue::Consumer do
         fake_consumer = double('Consumer', connection: nil, terminate: nil)
         allow(FakeMessageQueue::Consumer).to receive(:new).and_return(fake_consumer)
 
+        consumer.connect
         consumer.terminate
 
         expect(fake_consumer).to have_received(:terminate)

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe MessageQueue::Consumer do
   describe 'when using the fake queue', fake_queue: true do
     before(:example) do
       @fake_consumer = fake_consumer
-     allow(FakeMessageQueue::Consumer).to receive(:new).and_return(@fake_consumer)
-     consumer.connect
-   end
+      allow(FakeMessageQueue::Consumer).to receive(:new).and_return(@fake_consumer)
+      consumer.connect
+    end
 
     it 'forwards #pop to FakeMessageQueue::Consumer' do
       consumer.pop
@@ -73,6 +73,5 @@ RSpec.describe MessageQueue::Consumer do
           ssl_context: nil,
         ).at_least(:once)
     end
-
   end
 end

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -72,4 +72,25 @@ RSpec.describe MessageQueue::Consumer do
       end
     end
   end
+
+  let(:fake_consumer) { double 'Consumer', connection: nil, terminate: nil, pop: :popped }
+
+  describe 'when using the real queue', fake_queue: false do
+    before(:each) { allow(Nsq::Consumer).to receive(:new).and_return(fake_consumer) }
+
+    it 'forwards #pop to Nsq::Consumer' do
+      consumer.pop
+      expect(fake_consumer).to have_received(:pop)
+    end
+  end
+
+  describe 'when using the fake queue', fake_queue: true do
+    let(:fake_consumer) { double 'Consumer', connection: nil, terminate: nil, pop: :popped }
+    before(:each) { allow(FakeMessageQueue::Consumer).to receive(:new).and_return(fake_consumer) }
+
+    it 'forwards #pop to FakeMessageQueue::Consumer' do
+      consumer.pop
+      expect(fake_consumer).to have_received(:pop)
+    end
+  end
 end

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -5,38 +5,8 @@ RSpec.describe MessageQueue::Consumer do
   let(:topic)    { 'death_star' }
   let(:consumer) { MessageQueue::Consumer.new(topic: topic, channel: channel) }
 
-  describe '#connection' do
-    describe 'when using the real queue', fake_queue: false do
-      it 'returns an instance of the queue consumer' do
-        allow(Nsq::Consumer).to receive(:new)
-
-        consumer.connect
-
-        expect(Nsq::Consumer).to have_received(:new).
-          with(
-            nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
-            topic: topic,
-            channel: channel,
-            ssl_context: nil,
-          ).at_least(:once)
-      end
-    end
-
-    describe 'when using the fake queue', fake_queue: true do
-      it 'returns an instance of the queue consumer' do
-        allow(FakeMessageQueue::Consumer).to receive(:new)
-
-        consumer.connect
-
-        expect(FakeMessageQueue::Consumer).to have_received(:new).
-          with(
-            nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
-            topic: topic,
-            channel: channel,
-            ssl_context: nil,
-          ).at_least(:once)
-      end
-    end
+  def fake_consumer
+    double 'Consumer', connection: nil, terminate: nil, pop: :popped
   end
 
   describe 'when the ENV is set incorrectly' do
@@ -47,50 +17,62 @@ RSpec.describe MessageQueue::Consumer do
     end
   end
 
-  describe '#terminate' do
-    describe 'when using the real queue', fake_queue: false do
-      it 'closes the connection' do
-        fake_consumer = double('Consumer', connection: nil, terminate: nil)
-        allow(Nsq::Consumer).to receive(:new).and_return(fake_consumer)
-
-        consumer.connect
-        consumer.terminate
-
-        expect(fake_consumer).to have_received(:terminate)
-      end
-    end
-
-    describe 'when using the fake queue', fake_queue: true do
-      it 'closes the connection' do
-        fake_consumer = double('Consumer', connection: nil, terminate: nil)
-        allow(FakeMessageQueue::Consumer).to receive(:new).and_return(fake_consumer)
-
-        consumer.connect
-        consumer.terminate
-
-        expect(fake_consumer).to have_received(:terminate)
-      end
-    end
-  end
-
-  let(:fake_consumer) { double 'Consumer', connection: nil, terminate: nil, pop: :popped }
-
   describe 'when using the real queue', fake_queue: false do
-    before(:each) { allow(Nsq::Consumer).to receive(:new).and_return(fake_consumer) }
+    before(:example) do
+      @fake_consumer = fake_consumer
+      allow(Nsq::Consumer).to receive(:new).and_return(@fake_consumer)
+      consumer.connect
+    end
 
     it 'forwards #pop to Nsq::Consumer' do
       consumer.pop
-      expect(fake_consumer).to have_received(:pop)
+      expect(@fake_consumer).to have_received(:pop)
+    end
+
+    it 'closes the connection' do
+      consumer.terminate
+
+      expect(@fake_consumer).to have_received(:terminate)
+    end
+
+    it 'instantiates the queue consumer' do
+      expect(Nsq::Consumer).to have_received(:new).
+        with(
+          nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
+          topic: topic,
+          channel: channel,
+          ssl_context: nil,
+        ).at_least(:once)
     end
   end
 
   describe 'when using the fake queue', fake_queue: true do
-    let(:fake_consumer) { double 'Consumer', connection: nil, terminate: nil, pop: :popped }
-    before(:each) { allow(FakeMessageQueue::Consumer).to receive(:new).and_return(fake_consumer) }
+    before(:example) do
+      @fake_consumer = fake_consumer
+     allow(FakeMessageQueue::Consumer).to receive(:new).and_return(@fake_consumer)
+     consumer.connect
+   end
 
     it 'forwards #pop to FakeMessageQueue::Consumer' do
       consumer.pop
-      expect(fake_consumer).to have_received(:pop)
+      expect(@fake_consumer).to have_received(:pop)
     end
+
+    it 'closes the connection' do
+      consumer.terminate
+
+      expect(@fake_consumer).to have_received(:terminate)
+    end
+
+    it 'instantiates the queue consumer' do
+      expect(FakeMessageQueue::Consumer).to have_received(:new).
+        with(
+          nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
+          topic: topic,
+          channel: channel,
+          ssl_context: nil,
+        ).at_least(:once)
+    end
+
   end
 end

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MessageQueue::Consumer do
         topic = 'death_star'
         channel = 'star_killer_base'
 
-        MessageQueue::Consumer.new(topic: topic, channel: channel).connection
+        MessageQueue::Consumer.new(topic: topic, channel: channel).connect
 
         expect(Nsq::Consumer).to have_received(:new).
           with(
@@ -26,7 +26,7 @@ RSpec.describe MessageQueue::Consumer do
         topic = 'death_star'
         channel = 'star_killer_base'
 
-        MessageQueue::Consumer.new(topic: topic, channel: channel).connection
+        MessageQueue::Consumer.new(topic: topic, channel: channel).connect
 
         expect(FakeMessageQueue::Consumer).to have_received(:new).
           with(
@@ -47,7 +47,7 @@ RSpec.describe MessageQueue::Consumer do
 
       consumer = MessageQueue::Consumer.new(topic: topic, channel: channel)
 
-      expect { consumer.connection }.to raise_error(InvalidParameterError)
+      expect { consumer.connect }.to raise_error(InvalidParameterError)
     end
   end
 

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MessageQueue::Consumer do
   let(:consumer) { MessageQueue::Consumer.new(topic: topic, channel: channel) }
 
   def fake_consumer
-    double 'Consumer', connection: nil, terminate: nil, pop: :popped
+    double 'Consumer', connection: nil, terminate: nil, pop: :popped, size: 0
   end
 
   describe 'when the ENV is set incorrectly' do
@@ -28,7 +28,12 @@ RSpec.describe MessageQueue::Consumer do
       expect(@fake_consumer).to have_received(:pop)
     end
 
-    it 'closes the connection' do
+    it 'forwards #size to Nsq::Consumer' do
+      consumer.size
+      expect(@fake_consumer).to have_received(:size)
+    end
+
+    it 'forwards #terminate to Nsq::Consumer' do
       consumer.terminate
 
       expect(@fake_consumer).to have_received(:terminate)
@@ -46,7 +51,12 @@ RSpec.describe MessageQueue::Consumer do
       expect(@fake_consumer).to have_received(:pop)
     end
 
-    it 'closes the connection' do
+    it 'forwards #size to FakeMessageQueue::Consumer' do
+      consumer.size
+      expect(@fake_consumer).to have_received(:size)
+    end
+
+    it 'forwards #terminate to FakeMessageQueue::Consumer' do
       consumer.terminate
 
       expect(@fake_consumer).to have_received(:terminate)

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe MessageQueue::Consumer do
   describe '#terminate' do
     describe 'when using the real queue', fake_queue: false do
       it 'closes the connection' do
-        consumer = double('Consumer', connection: nil, terminate: nil)
-        allow(Nsq::Consumer).to receive(:new).and_return(consumer)
+        fake_consumer = double('Consumer', connection: nil, terminate: nil)
+        allow(Nsq::Consumer).to receive(:new).and_return(fake_consumer)
 
         consumer.terminate
 
-        expect(consumer).to have_received(:terminate)
+        expect(fake_consumer).to have_received(:terminate)
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe MessageQueue::Consumer do
 
         consumer.terminate
 
-        expect(consumer).to have_received(:terminate)
+        expect(fake_consumer).to have_received(:terminate)
       end
     end
   end

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MessageQueue::Consumer do
     it 'raises with a helpful error' do
       allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return('taco')
 
-      expect { consumer.connect }.to raise_error(InvalidParameterError)
+      expect { consumer.terminate }.to raise_error(InvalidParameterError)
     end
   end
 

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe MessageQueue::Consumer do
     before(:example) do
       @fake_consumer = fake_consumer
       allow(Nsq::Consumer).to receive(:new).and_return(@fake_consumer)
-      consumer.connect
     end
 
     it 'forwards #pop to Nsq::Consumer' do
@@ -34,23 +33,12 @@ RSpec.describe MessageQueue::Consumer do
 
       expect(@fake_consumer).to have_received(:terminate)
     end
-
-    it 'instantiates the queue consumer' do
-      expect(Nsq::Consumer).to have_received(:new).
-        with(
-          nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
-          topic: topic,
-          channel: channel,
-          ssl_context: nil,
-        ).at_least(:once)
-    end
   end
 
   describe 'when using the fake queue', fake_queue: true do
     before(:example) do
       @fake_consumer = fake_consumer
       allow(FakeMessageQueue::Consumer).to receive(:new).and_return(@fake_consumer)
-      consumer.connect
     end
 
     it 'forwards #pop to FakeMessageQueue::Consumer' do
@@ -62,16 +50,6 @@ RSpec.describe MessageQueue::Consumer do
       consumer.terminate
 
       expect(@fake_consumer).to have_received(:terminate)
-    end
-
-    it 'instantiates the queue consumer' do
-      expect(FakeMessageQueue::Consumer).to have_received(:new).
-        with(
-          nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
-          topic: topic,
-          channel: channel,
-          ssl_context: nil,
-        ).at_least(:once)
     end
   end
 end

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -70,13 +70,16 @@ RSpec.describe MessageQueue::Listener do
     end
 
     context 'when using the fake queue and it is empty', fake_queue: true do
+      before do
+        FakeMessageQueue.delay = 0.1
+      end
+
       it 'blocks on the process for longer than the check cycle' do
-        delay = FakeMessageQueue::Consumer::SECONDS_BETWEEN_QUEUE_CHECKS + 0.1
+        delay = FakeMessageQueue.delay + 0.1
 
         expect do
           Timeout.timeout(delay) do
-            MessageQueue::Listener.new(topic: topic, channel: channel).
-              process_next_message
+            listener.process_next_message
           end
         end.to raise_error(Timeout::Error)
       end

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe MessageQueue::Listener do
   module TestMessageProcessor
     @@messages_processed = []
     Message = Struct.new(:body, :topic) do
-      def finish; @did_finish = true; end
+      def finish
+        @did_finish = true
+      end
     end
 
     def self.call(body, topic)

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -86,12 +86,6 @@ RSpec.describe MessageQueue::Listener do
   describe '#go' do
     describe 'when a SIGTERM is received' do
       it 'closes the consumer connection' do
-        allow(SampleMessageProcessor).to receive_message_chain(:new, :go)
-        message = double(finish: nil, body: nil)
-        connection = double('Connection', pop: message, terminate: nil)
-        consumer = double('Consumer', connection: connection)
-        allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
-
         pid = fork do
           MessageQueue::Listener.new(topic: topic, channel: channel).go
         end

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe MessageQueue::Listener do
+  let(:topic)   { 'testing_topic' }
+  let(:channel) { 'testing_channel' }
+
   describe '#process_next_message' do
     it 'pass the topic and channel to the consumer' do
       allow(SampleMessageProcessor).to receive_message_chain(:new, :go)
@@ -8,8 +11,6 @@ RSpec.describe MessageQueue::Listener do
       connection = double('Connection', pop: message, terminate: nil)
       consumer = double('Consumer', connection: connection)
       allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
-      topic = 'testing_topic'
-      channel = 'testing_channel'
 
       MessageQueue::Listener.new(topic: topic, channel: channel).
         process_next_message
@@ -26,8 +27,6 @@ RSpec.describe MessageQueue::Listener do
       connection = double('Connection', pop: message, terminate: nil)
       consumer = double('Consumer', connection: connection)
       allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
-      topic = 'testing_topic'
-      channel = 'testing_channel'
 
       MessageQueue::Listener.new(topic: topic, channel: channel).
         process_next_message
@@ -43,8 +42,6 @@ RSpec.describe MessageQueue::Listener do
       connection = double('Connection', pop: message, terminate: nil)
       consumer = double('Consumer', connection: connection)
       allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
-      topic = 'testing_topic'
-      channel = 'testing_channel'
 
       MessageQueue::Listener.new(topic: topic, channel: channel).
         process_next_message
@@ -54,8 +51,6 @@ RSpec.describe MessageQueue::Listener do
 
     context 'when using the fake queue and it is empty', fake_queue: true do
       it 'blocks on the process for longer than the check cycle' do
-        topic = 'testing_topic'
-        channel = 'testing_channel'
         delay = FakeMessageQueue::Consumer::SECONDS_BETWEEN_QUEUE_CHECKS + 0.1
 
         expect do
@@ -76,8 +71,6 @@ RSpec.describe MessageQueue::Listener do
         connection = double('Connection', pop: message, terminate: nil)
         consumer = double('Consumer', connection: connection)
         allow(MessageQueue::Consumer).to receive(:new).and_return(consumer)
-        topic = 'testing_topic'
-        channel = 'testing_channel'
 
         pid = fork do
           MessageQueue::Listener.new(topic: topic, channel: channel).go

--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe MessageQueue::Listener do
   let(:message)            { TestMessageProcessor::Message.new 'this is message body', topic }
   let(:messages_processed) { TestMessageProcessor.messages_processed }
   let(:expected_message)   { TestMessageProcessor::Message.new('this is message body', topic) }
-  let(:expected_messages)  { [ expected_message ] }
+  let(:expected_messages)  { [expected_message] }
 
   describe 'instantiating without a consumer' do
     it 'instantiates a consumer, passing the topic and channel' do


### PR DESCRIPTION
`Listener#consumer` attaches to `MQ::Consumer#connection` instead of `MQ::Consumer`. I'm :new: here, but I _think_ this means that we have the actual `nsq-ruby` object inside `Listener`, instead of the `MQ::Consumer` wrapper. And, possibly tangentially, that `Listener` doesn't actually respect the `fake` queue `Strategy` (since `FakeMessageQueue::Consumer` doesn't implement `connection`)

This change breaks some tests. I thought I'd check in and see if I've wildly misunderstood any of this, before I stumbled around too much in fixing these.

---

So: I continued to run with the idea that Consumer should wrap the under NSQ Consumer, and that, in effect, MessageQueue::Consumer#connection ought to be private. Made tests pass. Along the way, some refactoring occurred, mostly in tests.

Assuming review shakes out, this should probably also bump the gem version, since we may need time to get downstream services weaned off of using #connection directly.
