### PR TITLE
Producer#connection -> Producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ message_data = {
 producer = MessageQueue::Producer.new(
   nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
   topic: topic,
-).connection
+)
 
 producer.write(message_data.to_json)
 ```

--- a/lib/fastly_nsq/fake_message_queue.rb
+++ b/lib/fastly_nsq/fake_message_queue.rb
@@ -32,7 +32,7 @@ module FakeMessageQueue
   end
 
   class Producer
-    def initialize(nsqd:, topic:, ssl_context: nil)
+    def initialize(topic:, nsqd: nil, ssl_context: nil)
     end
 
     def write(string)

--- a/lib/fastly_nsq/message_queue/producer.rb
+++ b/lib/fastly_nsq/message_queue/producer.rb
@@ -8,7 +8,7 @@ module MessageQueue
     def_delegator :connection, :terminate
     def_delegator :connection, :write
 
-    def initialize(topic:, ssl_context: nil, &connector)
+    def initialize(topic:, ssl_context: nil, connector: nil)
       @topic       = topic
       @ssl_context = SSLContext.new(ssl_context)
       @connector   = connector || DEFAULT_CONNECTOR

--- a/lib/fastly_nsq/message_queue/producer.rb
+++ b/lib/fastly_nsq/message_queue/producer.rb
@@ -1,26 +1,24 @@
+require 'forwardable'
+
 class InvalidParameterError < StandardError; end
 
 module MessageQueue
   class Producer
+    extend Forwardable
+    def_delegator :connection, :terminate
+    def_delegator :connection, :write
+
     def initialize(topic:, ssl_context: nil)
       @topic = topic
       @ssl_context = SSLContext.new(ssl_context)
-    end
-
-    def connection
-      @producer ||= producer.new(params)
-    end
-
-    def terminate
-      @producer.terminate
     end
 
     private
 
     attr_reader :topic, :ssl_context
 
-    def producer
-      Strategy.for_queue::Producer
+    def connection
+      Strategy.for_queue::Producer.new params
     end
 
     def params

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.6.0'.freeze
 end

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -54,10 +54,6 @@ RSpec.describe FakeMessageQueue::Producer do
 end
 
 RSpec.describe FakeMessageQueue::Message do
-  after do
-    FakeMessageQueue.reset!
-  end
-
   describe '#body' do
     it 'returns the body of the message' do
       topic = 'death_star'
@@ -80,10 +76,6 @@ RSpec.describe FakeMessageQueue::Consumer do
   let(:topic)    { 'death_star' }
   let(:channel)  { 'star_killer_base' }
   let(:consumer) { FakeMessageQueue::Consumer.new topic: topic, channel: channel }
-
-  after do
-    FakeMessageQueue.reset!
-  end
 
   describe 'when there are no messages on the queue' do
     it 'tells you there are 0 messages in the queue' do

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe FakeMessageQueue::Producer do
   end
 
   it 'has a `terminate` method which is a noop' do
-    expect(producer.respond_to?(:terminate)).to be_truthy
+    expect(producer).to respond_to(:terminate)
   end
 end
 

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -37,30 +37,19 @@ RSpec.describe FakeMessageQueue do
 end
 
 RSpec.describe FakeMessageQueue::Producer do
-  after do
-    FakeMessageQueue.reset!
+  after { FakeMessageQueue.reset! }
+
+  let(:topic)    { 'death_star' }
+  let(:producer) { FakeMessageQueue::Producer.new topic: topic }
+
+  it 'adds a new message to the queue' do
+    producer.write('hello')
+
+    expect(FakeMessageQueue.queue.size).to eq 1
   end
 
-  describe '#write' do
-    it 'adds a new message to the queue' do
-      topic = 'death_star'
-
-      producer = FakeMessageQueue::Producer.new(
-        nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
-        topic: topic,
-      )
-      producer.write('hello')
-
-      expect(FakeMessageQueue.queue.size).to eq 1
-    end
-  end
-
-  describe '#terminate' do
-    it 'has a `terminate` method which is a noop' do
-      producer = instance_double('FakeMessageQueue::Producer')
-
-      allow(producer).to receive(:terminate)
-    end
+  it 'has a `terminate` method which is a noop' do
+    expect(producer.respond_to?(:terminate)).to be_truthy
   end
 end
 

--- a/spec/lib/fastly_nsq/fake_message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/fake_message_queue_spec.rb
@@ -37,8 +37,6 @@ RSpec.describe FakeMessageQueue do
 end
 
 RSpec.describe FakeMessageQueue::Producer do
-  after { FakeMessageQueue.reset! }
-
   let(:topic)    { 'death_star' }
   let(:producer) { FakeMessageQueue::Producer.new topic: topic }
 

--- a/spec/lib/fastly_nsq/message_queue/producer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/producer_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe MessageQueue::Producer do
+  let(:topic) { 'death_star' }
+
   describe '#connection' do
     describe 'when using the real queue', fake_queue: false do
       it 'returns an instance of the queue producer' do
         allow(Nsq::Producer).to receive(:new)
-        topic = 'death_star'
 
         MessageQueue::Producer.new(topic: topic).connection
 
@@ -21,7 +22,6 @@ RSpec.describe MessageQueue::Producer do
     describe 'when using the fake queue', fake_queue: true do
       it 'returns an instance of the queue producer' do
         allow(FakeMessageQueue::Producer).to receive(:new)
-        topic = 'death_star'
 
         MessageQueue::Producer.new(topic: topic).connection
 
@@ -37,7 +37,6 @@ RSpec.describe MessageQueue::Producer do
     describe 'when the ENV is set incorrectly' do
       it 'raises with a helpful error' do
         allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return('taco')
-        topic = 'death_star'
 
         producer = MessageQueue::Producer.new(topic: topic)
 
@@ -51,7 +50,6 @@ RSpec.describe MessageQueue::Producer do
       it 'closes the connection' do
         producer = double('Producer', connection: nil, terminate: nil)
         allow(Nsq::Producer).to receive(:new).and_return(producer)
-        topic = 'death_star'
 
         live_producer = MessageQueue::Producer.new(topic: topic)
         live_producer.connection
@@ -65,7 +63,6 @@ RSpec.describe MessageQueue::Producer do
       it 'closes the connection' do
         producer = double('Producer', connection: nil, terminate: nil)
         allow(FakeMessageQueue::Producer).to receive(:new).and_return(producer)
-        topic = 'death_star'
 
         live_producer = MessageQueue::Producer.new(topic: topic)
         live_producer.connection

--- a/spec/lib/fastly_nsq/message_queue/producer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/producer_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe MessageQueue::Producer do
     end
 
     it 'forwards #write' do
-      expect(backend).to receive(:write)
-      producer.write "message"
+      expect(backend).to receive(:write).with("it's a message")
+      producer.write "it's a message"
     end
 
     it 'forwards #terminate' do

--- a/spec/lib/fastly_nsq/message_queue/producer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/producer_spec.rb
@@ -48,6 +48,5 @@ RSpec.describe MessageQueue::Producer do
       producer.write
       expect(@fake_producer).to have_received(:write)
     end
-
   end
 end

--- a/spec/lib/fastly_nsq/message_queue/producer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/producer_spec.rb
@@ -1,12 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe MessageQueue::Producer do
-  let(:topic) { 'death_star' }
+  let(:topic)    { 'death_star' }
   let(:producer) { MessageQueue::Producer.new(topic: topic) }
-
-  def fake_producer
-    double 'Producer', connection: nil, terminate: nil, write: :written
-  end
+  let(:backend)  { double 'Producer' }
 
   describe 'when the ENV is set incorrectly' do
     it 'raises with a helpful error' do
@@ -16,37 +13,39 @@ RSpec.describe MessageQueue::Producer do
     end
   end
 
-  describe 'when using the real queue', fake_queue: false do
-    before(:example) do
-      @fake_producer = fake_producer
-      allow(Nsq::Producer).to receive(:new).and_return(@fake_producer)
+  describe 'when connector connects to a backend Producer' do
+    let(:producer) do
+      MessageQueue::Producer.new topic: topic do
+        backend
+      end
     end
 
-    it 'forwards #terminate to Nsq::Producer' do
+    it 'forwards #write' do
+      expect(backend).to receive(:write)
+      producer.write "message"
+    end
+
+    it 'forwards #terminate' do
+      expect(backend).to receive(:terminate)
       producer.terminate
-      expect(@fake_producer).to have_received(:terminate)
-    end
-
-    it 'forwards #write to Nsq::Producer' do
-      producer.write
-      expect(@fake_producer).to have_received(:write)
     end
   end
 
-  describe 'when using the fake queue', fake_queue: true do
-    before(:example) do
-      @fake_producer = fake_producer
-      allow(FakeMessageQueue::Producer).to receive(:new).and_return(@fake_producer)
+  describe 'using the default connector' do
+    module TestStrategy
+      module Producer
+        def self.new(*_); end
+      end
     end
 
-    it 'forwards #terminate to the FakeMessageQueue::Producer' do
+    before do
+      allow(Strategy).to receive(:for_queue).and_return(TestStrategy)
+    end
+
+    it 'instantiates a producer via Strategy' do
+      allow(backend).to receive(:terminate)
+      expect(TestStrategy::Producer).to receive(:new).and_return(backend)
       producer.terminate
-      expect(@fake_producer).to have_received(:terminate)
-    end
-
-    it 'forwards #write to FakeMessageQueue::Producer' do
-      producer.write
-      expect(@fake_producer).to have_received(:write)
     end
   end
 end

--- a/spec/lib/fastly_nsq/message_queue/producer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/producer_spec.rb
@@ -15,9 +15,7 @@ RSpec.describe MessageQueue::Producer do
 
   describe 'when connector connects to a backend Producer' do
     let(:producer) do
-      MessageQueue::Producer.new topic: topic do
-        backend
-      end
+      MessageQueue::Producer.new topic: topic, connector: ->(_) { backend }
     end
 
     it 'forwards #write' do


### PR DESCRIPTION
Continuing on [from working](https://github.com/fastly/fastly_nsq/pull/26) to make `Consumer#connection` private (in favor of using the actual `MessageQueue::Consumer` instance and delegating) this PR applies the same approach to `Producer#connection`.

@fastly/billing 
