### PR TITLE
Remove unnecessary listener spec

### DIFF
--- a/spec/lib/fastly_nsq/message_queue/listener_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/listener_spec.rb
@@ -87,21 +87,4 @@ RSpec.describe MessageQueue::Listener do
       end
     end
   end
-
-  describe '#go' do
-    describe 'when a SIGTERM is received' do
-      it 'closes the consumer connection' do
-        pid = fork do
-          MessageQueue::Listener.new(topic: topic, channel: channel).go
-        end
-
-        Process.kill('TERM', pid)
-
-        # Success for this test is to expect it to complete.
-        #
-        # Additional Note: We are NOT testing the SIGINT case because it
-        # orphans the test's Ruby process and is thus meaningless as a test.
-      end
-    end
-  end
 end


### PR DESCRIPTION
# Reason for Change
- This spec does not accurately test the code it is targeting.
- Because the method is testing the behavior of a `SIGTERM`, it actually interferes with the running RSpec process.
- As noted in #27, the test will pass if the relevant code is removed.
# Changes
- Remove the spec in question.
- NOTE: This method is now untested. Since it's the same as another method, but run in a loop, it's probably fine.
# Risks
- One method is now untested, but this feels like a minor risk.
# Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR._
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream
# Recommended Reviewers

@fastly/billing
#27
