### PR TITLE
Persist connection

### DIFF
--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -10,7 +10,7 @@ module MessageQueue
     def_delegator :connection, :size
     def_delegator :connection, :terminate
 
-    def initialize(topic:, channel:, ssl_context: nil, &connector)
+    def initialize(topic:, channel:, ssl_context: nil, connector: nil)
       @topic       = topic
       @channel     = channel
       @ssl_context = SSLContext.new(ssl_context)

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -10,18 +10,21 @@ module MessageQueue
     def_delegator :connection, :size
     def_delegator :connection, :terminate
 
-    def initialize(topic:, channel:, ssl_context: nil)
+    def initialize(topic:, channel:, ssl_context: nil, &connector)
       @topic = topic
       @channel = channel
       @ssl_context = SSLContext.new(ssl_context)
+      @connector = connector || DEFAULT_CONNECTOR
     end
 
     private
 
-    attr_reader :channel, :topic, :ssl_context
+    attr_reader :channel, :connector, :topic, :ssl_context
+
+    DEFAULT_CONNECTOR = ->(params)  { Strategy.for_queue::Consumer.new(params) }
 
     def connection
-      @connection ||= Strategy.for_queue::Consumer.new(params)
+      @connection ||= connector.call(params)
     end
 
     def params

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -21,7 +21,7 @@ module MessageQueue
 
     attr_reader :channel, :connector, :topic, :ssl_context
 
-    DEFAULT_CONNECTOR = ->(params)  { Strategy.for_queue::Consumer.new(params) }
+    DEFAULT_CONNECTOR = ->(params) { Strategy.for_queue::Consumer.new(params) }
 
     def connection
       @connection ||= connector.call(params)

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -11,10 +11,10 @@ module MessageQueue
     def_delegator :connection, :terminate
 
     def initialize(topic:, channel:, ssl_context: nil, &connector)
-      @topic = topic
-      @channel = channel
+      @topic       = topic
+      @channel     = channel
       @ssl_context = SSLContext.new(ssl_context)
-      @connector = connector || DEFAULT_CONNECTOR
+      @connector   = connector || DEFAULT_CONNECTOR
     end
 
     private

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -21,7 +21,7 @@ module MessageQueue
     attr_reader :channel, :topic, :ssl_context
 
     def connection
-      Strategy.for_queue::Consumer.new(params)
+      @connection ||= Strategy.for_queue::Consumer.new(params)
     end
 
     def params

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.5.1'.freeze
 end

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe MessageQueue::Consumer do
   let(:channel)  { 'star_killer_base' }
   let(:topic)    { 'death_star' }
-  let(:consumer) { MessageQueue::Consumer.new(topic: topic, channel: channel) }
+  let(:consumer) { MessageQueue::Consumer.new topic: topic, channel: channel }
   let(:backend)  { double 'Consumer' }
 
   describe 'when the ENV is set incorrectly' do
@@ -16,9 +16,7 @@ RSpec.describe MessageQueue::Consumer do
 
   describe 'when connector connects to a backend Consumer' do
     let(:consumer) do
-      MessageQueue::Consumer.new topic: topic, channel: channel do
-        backend
-      end
+      MessageQueue::Consumer.new topic: topic, channel: channel, connector: ->(_) { backend }
     end
 
     it 'forwards #pop' do

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe MessageQueue::Consumer do
     end
 
     before do
-      allow(Strategy).to receive(:for_queue).and_return(TestStrategy)
+      allow(MessageQueue).to receive(:strategy).and_return(TestStrategy)
     end
 
     it 'instantiates a consumer via Strategy' do

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe MessageQueue::Consumer do
   describe 'using the default connector' do
     module TestStrategy
       module Consumer
-        def self.new(*args); end
+        def self.new(*_); end
       end
     end
 

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe MessageQueue::Consumer do
   let(:topic)    { 'death_star' }
   let(:consumer) { MessageQueue::Consumer.new(topic: topic, channel: channel) }
 
-  def fake_consumer
-    double 'Consumer', connection: nil, terminate: nil, pop: :popped, size: 0
-  end
-
   describe 'when the ENV is set incorrectly' do
     it 'raises with a helpful error' do
       allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return('taco')
@@ -19,7 +15,8 @@ RSpec.describe MessageQueue::Consumer do
 
   describe 'when using the real queue', fake_queue: false do
     before(:example) do
-      @fake_consumer = fake_consumer
+      @fake_consumer = spy 'Consumer backend'
+      consumer.instance_variable_set("@connection", nil)
       allow(Nsq::Consumer).to receive(:new).and_return(@fake_consumer)
     end
 
@@ -28,12 +25,7 @@ RSpec.describe MessageQueue::Consumer do
       expect(@fake_consumer).to have_received(:pop)
     end
 
-    it 'forwards #size to Nsq::Consumer' do
-      consumer.size
-      expect(@fake_consumer).to have_received(:size)
-    end
-
-    it 'forwards #terminate to Nsq::Consumer' do
+    it 'closes the connection' do
       consumer.terminate
 
       expect(@fake_consumer).to have_received(:terminate)
@@ -42,7 +34,8 @@ RSpec.describe MessageQueue::Consumer do
 
   describe 'when using the fake queue', fake_queue: true do
     before(:example) do
-      @fake_consumer = fake_consumer
+      @fake_consumer = spy 'Consumer backend'
+      consumer.instance_variable_set("@connection", nil)
       allow(FakeMessageQueue::Consumer).to receive(:new).and_return(@fake_consumer)
     end
 
@@ -51,12 +44,7 @@ RSpec.describe MessageQueue::Consumer do
       expect(@fake_consumer).to have_received(:pop)
     end
 
-    it 'forwards #size to FakeMessageQueue::Consumer' do
-      consumer.size
-      expect(@fake_consumer).to have_received(:size)
-    end
-
-    it 'forwards #terminate to FakeMessageQueue::Consumer' do
+    it 'closes the connection' do
       consumer.terminate
 
       expect(@fake_consumer).to have_received(:terminate)

--- a/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/consumer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe MessageQueue::Consumer do
   describe 'when using the real queue', fake_queue: false do
     before(:example) do
       @fake_consumer = spy 'Consumer backend'
-      consumer.instance_variable_set("@connection", nil)
+      consumer.instance_variable_set('@connection', nil)
       allow(Nsq::Consumer).to receive(:new).and_return(@fake_consumer)
     end
 
@@ -35,7 +35,7 @@ RSpec.describe MessageQueue::Consumer do
   describe 'when using the fake queue', fake_queue: true do
     before(:example) do
       @fake_consumer = spy 'Consumer backend'
-      consumer.instance_variable_set("@connection", nil)
+      consumer.instance_variable_set('@connection', nil)
       allow(FakeMessageQueue::Consumer).to receive(:new).and_return(@fake_consumer)
     end
 

--- a/spec/lib/fastly_nsq/message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe MessageQueue do
-  TestStrategy = Class.new
+  module TestStrategy; end
 
   it 'allows the logger to be set and retrieved' do
     logger = Logger.new(STDOUT)


### PR DESCRIPTION
# Reason for Change

We're seeing NSQ connections leaking after tests.
# List of Changes
- Memoize #connection on Consumer
- Update spec to get around Rspec's mock scoping rules
# Risks

It feels ugly to manipulate test object's instance vars this way. At one point, I had a method like `reset` or something that could do this, but adding a method just for testing also felt ugly. I dunno.
# Recommended Reviewers

@fastly/billing tell me what I'm doing wrong here
