### PR TITLE
Strategy

### DIFF
--- a/lib/fastly_nsq/message_queue.rb
+++ b/lib/fastly_nsq/message_queue.rb
@@ -7,9 +7,6 @@ require_relative 'message_queue/strategy'
 require_relative 'ssl_context'
 
 module MessageQueue
-  FALSY_VALUES = [false, 0, '0', 'false', 'FALSE', 'off', 'OFF', nil].freeze
-  TRUTHY_VALUES = [true, 1, '1', 'true', 'TRUE', 'on', 'ON'].freeze
-
   def self.logger=(logger)
     strategy.logger = logger
   end

--- a/lib/fastly_nsq/message_queue/consumer.rb
+++ b/lib/fastly_nsq/message_queue/consumer.rb
@@ -21,7 +21,7 @@ module MessageQueue
     attr_reader :channel, :topic, :ssl_context
 
     def connection
-      Strategy.for_queue::Consumer.new(params)
+      MessageQueue.strategy::Consumer.new(params)
     end
 
     def params

--- a/lib/fastly_nsq/message_queue/producer.rb
+++ b/lib/fastly_nsq/message_queue/producer.rb
@@ -20,7 +20,7 @@ module MessageQueue
     attr_reader :topic, :ssl_context
 
     def producer
-      Strategy.for_queue::Producer
+      MessageQueue.strategy::Producer
     end
 
     def params

--- a/lib/fastly_nsq/message_queue/strategy.rb
+++ b/lib/fastly_nsq/message_queue/strategy.rb
@@ -8,5 +8,8 @@ class Strategy
       message = "You must set ENV['FAKE_QUEUE'] to either true or false"
       raise InvalidParameterError, message
     end
+
+  FALSY_VALUES  = [false, 0, '0', 'false', 'FALSE', 'off', 'OFF', nil].freeze
+  TRUTHY_VALUES = [true, 1, '1', 'true', 'TRUE', 'on', 'ON'].freeze
   end
 end

--- a/lib/fastly_nsq/message_queue/strategy.rb
+++ b/lib/fastly_nsq/message_queue/strategy.rb
@@ -1,15 +1,34 @@
-class Strategy
-  def self.for_queue
-    if MessageQueue::FALSY_VALUES.include?(ENV['FAKE_QUEUE'])
-      Nsq
-    elsif MessageQueue::TRUTHY_VALUES.include?(ENV['FAKE_QUEUE'])
-      FakeMessageQueue
-    else
-      message = "You must set ENV['FAKE_QUEUE'] to either true or false"
-      raise InvalidParameterError, message
-    end
+module MessageQueue::Strategy
+  module_function
+
+  def for_queue
+    real_queue || fake_queue || error
+  end
+
+  private_class_method
+
+  ERR_MESSAGE = "You must set ENV['FAKE_QUEUE'] to either true or false".freeze
+
+  def error
+    raise InvalidParameterError, ERR_MESSAGE
+  end
 
   FALSY_VALUES  = [false, 0, '0', 'false', 'FALSE', 'off', 'OFF', nil].freeze
   TRUTHY_VALUES = [true, 1, '1', 'true', 'TRUE', 'on', 'ON'].freeze
+
+  def fake_queue
+    FakeMessageQueue if should_use_fake_queue?
+  end
+
+  def should_use_real_queue?
+    FALSY_VALUES.include? ENV['FAKE_QUEUE']
+  end
+
+  def real_queue
+    Nsq if should_use_real_queue?
+  end
+
+  def should_use_fake_queue?
+    TRUTHY_VALUES.include? ENV['FAKE_QUEUE']
   end
 end

--- a/spec/lib/fastly_nsq/message_queue/strategy_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue/strategy_spec.rb
@@ -1,29 +1,35 @@
 require 'spec_helper'
 
-RSpec.describe Strategy do
-  describe '.for_queue' do
-    describe 'when using the fake queue', fake_queue: true do
-      it 'returns the strategy based on the ENV variable' do
-        strategy = Strategy.for_queue
+RSpec.describe MessageQueue::Strategy do
+  describe 'when FAKE_QUEUE is falsy' do
+    it 'returns the strategy based on the ENV variable' do
+      [false, 0, '0', 'false', 'FALSE', 'off', 'OFF', nil].each do |no|
+        allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(no)
 
-        expect(strategy).to eq FakeMessageQueue
-      end
-    end
-
-    describe 'when using the real queue', fake_queue: false do
-      it 'returns the strategy based on the ENV variable' do
-        strategy = Strategy.for_queue
+        strategy = MessageQueue::Strategy.for_queue
 
         expect(strategy).to eq Nsq
       end
     end
+  end
 
-    describe 'when the ENV is set incorrectly' do
-      it 'raises with a helpful error' do
-        allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return('taco')
+  describe 'when FAKE_QUEUE is truthy' do
+    it 'returns the strategy based on the ENV variable' do
+      [true, 1, '1', 'true', 'TRUE', 'on', 'ON'].each do |yes|
+        allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(yes)
 
-        expect { Strategy.for_queue }.to raise_error(InvalidParameterError)
+        strategy = MessageQueue::Strategy.for_queue
+
+        expect(strategy).to eq FakeMessageQueue
       end
+    end
+  end
+
+  describe 'when the ENV is set incorrectly' do
+    it 'raises with a helpful error' do
+      allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return('taco')
+
+      expect { MessageQueue::Strategy.for_queue }.to raise_error(InvalidParameterError)
     end
   end
 end

--- a/spec/lib/fastly_nsq/message_queue_spec.rb
+++ b/spec/lib/fastly_nsq/message_queue_spec.rb
@@ -1,14 +1,23 @@
 require 'spec_helper'
 
 RSpec.describe MessageQueue do
+  TestStrategy = Class.new
+
+  it 'allows the logger to be set and retrieved' do
+    logger = Logger.new(STDOUT)
+    MessageQueue.logger = logger
+
+    expect(MessageQueue.logger).to eq logger
+  end
+
+  it 'returns the current Strategy' do
+    allow(MessageQueue::Strategy).to receive(:for_queue).and_return(TestStrategy)
+
+    expect(MessageQueue.strategy).to eql(TestStrategy)
+  end
+
   describe '.logger' do
     describe 'when using the fake queue', fake_queue: true do
-      it 'allows the logger to be set and retrieved' do
-        logger = Logger.new(STDOUT)
-        MessageQueue.logger = logger
-
-        expect(MessageQueue.logger).to eq logger
-      end
     end
 
     describe 'when using the real queue, fake_queue: false' do

--- a/spec/support/env_helpers.rb
+++ b/spec/support/env_helpers.rb
@@ -1,16 +1,12 @@
 module EnvHelpers
   def use_fake_connection
-    MessageQueue::TRUTHY_VALUES.each do |yes|
-      allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(yes)
-      yield
-    end
+    allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(true)
+    yield
   end
 
   def use_real_connection
-    MessageQueue::FALSY_VALUES.each do |no|
-      allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(no)
-      yield
-    end
+    allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(false)
+    yield
   end
 end
 


### PR DESCRIPTION
# Reason for Change

Previously, the spec_helper set us up to run each test 7-8 times via:

``` ruby
  def use_fake_connection
    MessageQueue::Strategy::TRUTHY_VALUES.each do |yes|
      allow(ENV).to receive(:[]).with('FAKE_QUEUE').and_return(yes)
      yield
    end
  end
```
# List of Changes
- Reduce that back down to once
- Re-namespace & refactor `Strategy` (via "campsite rule")
# Risks

There are likely to be merge conflicts later with #32 & #29 

@fastly/billing 
