### PR TITLE
Update TravisCI > Slack integration key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 notifications:
   slack:
     rooms:
-      - 'fastly:hFvhBQKliYl9QAO3VujcrLhe#billy'
+      secure: Uo78FoH8dwSbt7BjTcfb62RXW8aU5h2se+bs0fHSXNrzh6D3Zl+JmwzMkgN8u7M6F0WsOy6RhilYggRYAGds4K1CUi0wGJOG86NaXB4igqBIdHa6f6vzMQZoXxJk8ekc/0NFCj2UV+2Obt6FpeUZvF0Y+u029k5gN0SROfrN+ANtSq+jbI8sdsCCsedXHgDWnGsZS1hHleiRF1Q6VfKnBFcewPP/W49gzbABlKk2MjkVhse6kg+7+LRXfnDxh+aaRXBGYfzmGn4+gS6Jey63U0woAa8TdP/THlwhgvvBS0kwMMaCss+Uq1690lnVV5MX84Fsm4C+A9gbdJmlansLrYRRWm4aaAf8IGlqRTwx3F2yNHTaPA2zmkooFtn1kTuz1J8L9NjsVPPkATMAg3rTIhel+YkVK8q0Q9N9A70+P2u+Rp3htgjxVPMN7Ve9GqejUEaw690Wsp4hCK5tINj8Aq42ET/RpQt4Rzx78Vk4jEK+9UsFuuRH+awAJu/UsnA0JMTq9Smgk2kE69McVNfYPXRIRQXWAkV2dc6FwI8AAmqRusTeyWMK9SOQNXhlmry5ltWfAnHtuKdq9delbc1iOkcj8u9sCBkTz0ZogsI2oHpLlrw2oHFe49kSOkB5HMSQo8IOR7yXHAZ41lmd87/T367bak9HGqsCrweJL7Vz2Mw=
     on_success: change
     on_failure: change
   email:


### PR DESCRIPTION
# Reason for Change
- We had previously committed a Slack API key for Travis notifications to this public repository.
- This is a security risk so the key has been invalidated.
- We need a new secure key instead to maintain notifications.
# Changes
- Invalidate the old integration key in Slack.
- Use the travis CLI tool to [encrypt the existing key](https://docs.travis-ci.com/user/notifications/#Slack-notifications) which we weren't using yet.

https://jira.corp.fastly.com/browse/SEC-1822
