### PR TITLE
Update PR template to warn against Jira URLs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
+__NOTE: Do NOT add any Jira links to this PR description or commits.  This is a public repository.__
+
 Reason for Change
 ===================
-Describe the big picture of your changes here to communicate why this pull
+* Describe the big picture of your changes here to communicate why this pull
 request should be accepted. If it fixes a bug or resolves a feature request,
 be sure to link to that issue.
 
@@ -11,7 +13,7 @@ List of Changes
 
 Risks
 =====
-Describe any risks you see to existing systems this fix or feature might have
+* Describe any risks you see to existing systems this fix or feature might have
 if those systems where to incorporate this change.
 
 Checklist
@@ -19,6 +21,7 @@ Checklist
 _Put an `x` in the boxes that apply. 
 You can also fill these out after creating the PR._
 
+- [ ] I have NOT linked to any Jira tickets.
 - [ ] I have linked to all relevant reference issues or work requests
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added or updated necessary documentation (if appropriate)
@@ -27,4 +30,4 @@ You can also fill these out after creating the PR._
 
 Recommended Reviewers
 =====================
-@alieander, ...
+@fastly/billing


### PR DESCRIPTION
# Reason for Change
- We should not be committing Jira URLs to any public repository or PR message.
- It's probably fine since everything is locked up tight, but it's bad form.
# Changes
- Add a warning at the top of the GitHub PR template.
## Minor
- Update the recommended reviewers to point at the billing team
# Risks

Describe any risks you see to existing systems this fix or feature might have
if those systems where to incorporate this change.
# Checklist

_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._
- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream
# Recommended Reviewers

@fastly/billing 
