### PR TITLE
call Thread#join only on threads we created

### DIFF
--- a/lib/fastly_nsq/rake_task.rb
+++ b/lib/fastly_nsq/rake_task.rb
@@ -44,7 +44,11 @@ module MessageQueue
         end
       end
 
-      listener_threads.map(&:join)
+      while listener_threads.any?(&:status) do
+        listener_threads.each do |thread|
+          thread.join(1)
+        end
+      end
     end
 
     def guard_missing_channel

--- a/lib/fastly_nsq/rake_task.rb
+++ b/lib/fastly_nsq/rake_task.rb
@@ -44,10 +44,11 @@ module MessageQueue
         end
       end
 
-      while listener_threads.any?(&:status)
+      loop do
         listener_threads.each do |thread|
           thread.join(1)
         end
+        break unless listener_threads.any?(&:status)
       end
     end
 

--- a/lib/fastly_nsq/rake_task.rb
+++ b/lib/fastly_nsq/rake_task.rb
@@ -44,7 +44,7 @@ module MessageQueue
         end
       end
 
-      while listener_threads.any?(&:status) do
+      while listener_threads.any?(&:status)
         listener_threads.each do |thread|
           thread.join(1)
         end

--- a/lib/fastly_nsq/rake_task.rb
+++ b/lib/fastly_nsq/rake_task.rb
@@ -34,19 +34,17 @@ module MessageQueue
     end
 
     def run_tasks
+      listener_threads = []
+
       topics.each do |topic|
-        Thread.new do
+        listener_threads << Thread.new do
           wrap_helpful_output(topic) do
             MessageQueue::Listener.new(topic: topic, channel: channel).go
           end
         end
       end
 
-      non_main_threads.map(&:join)
-    end
-
-    def non_main_threads
-      (Thread.list - [Thread.main])
+      listener_threads.map(&:join)
     end
 
     def guard_missing_channel

--- a/lib/fastly_nsq/rake_task.rb
+++ b/lib/fastly_nsq/rake_task.rb
@@ -37,19 +37,16 @@ module MessageQueue
       listener_threads = []
 
       topics.each do |topic|
-        listener_threads << Thread.new do
+        thread = Thread.new do
           wrap_helpful_output(topic) do
             MessageQueue::Listener.new(topic: topic, channel: channel).go
           end
         end
+        thread.abort_on_exception = true
+        listener_threads << thread
       end
 
-      loop do
-        listener_threads.each do |thread|
-          thread.join(1)
-        end
-        break unless listener_threads.any?(&:status)
-      end
+      listener_threads.map(&:join)
     end
 
     def guard_missing_channel


### PR DESCRIPTION
# Reason for Change

We where using `Thread.list` which could likely contain things we did not
start. This switches to saving the threads we create in an array and
calling `Thread#join` on only the ones we have started.

We could also select only non-dead threads from this list by doing

```
listener_threads.select(&:status).map(&:join)
```

but by including threads that have already died, we allow them to
express whatever exception might have been raised back to the main
thread effectively halting the main Thread as they are left un-handled
there.`Thread.list` would have not returned "dead" threads here as we
where using it, so it was possible for a Thread to fail immediately and
have `join` never be called on it making it's failure silent.
# List of Changes
- alter rake task to save list of created listeners rather than use `Thread.list`
# Recommended Reviewers

@fastly/billing
