### PR TITLE
we should produce to a lookup as well

### DIFF
--- a/lib/fastly_nsq/fake_backend.rb
+++ b/lib/fastly_nsq/fake_backend.rb
@@ -33,7 +33,7 @@ module FastlyNsq
     end
 
     class Producer
-      def initialize(topic:, nsqd: nil, tls_v1: nil, tls_options: nil)
+      def initialize(topic:, nsqlookupd: nil, tls_v1: nil, tls_options: nil)
       end
 
       def write(string)

--- a/lib/fastly_nsq/producer.rb
+++ b/lib/fastly_nsq/producer.rb
@@ -26,7 +26,7 @@ module FastlyNsq
 
     def params
       {
-        nsqd:        ENV.fetch('NSQD_TCP_ADDRESS'),
+        nsqlookupd:  ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS').split(',').map(&:strip),
         topic:       topic,
       }.merge(tls_options)
     end

--- a/spec/lib/fastly_nsq/fake_backend_spec.rb
+++ b/spec/lib/fastly_nsq/fake_backend_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe FastlyNsq::FakeBackend::Message do
       topic = 'death_star'
       content = 'hello'
       producer = FastlyNsq::FakeBackend::Producer.new(
-        nsqd: ENV.fetch('NSQD_TCP_ADDRESS'),
+        nsqlookupd: ENV.fetch('NSQD_TCP_ADDRESS'),
         topic: topic,
       )
       producer.write(content)

--- a/spec/lib/fastly_nsq/fake_backend_spec.rb
+++ b/spec/lib/fastly_nsq/fake_backend_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe FastlyNsq::FakeBackend::Message do
       topic = 'death_star'
       content = 'hello'
       producer = FastlyNsq::FakeBackend::Producer.new(
-        nsqlookupd: ENV.fetch('NSQD_TCP_ADDRESS'),
+        nsqlookupd: ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS'),
         topic: topic,
       )
       producer.write(content)


### PR DESCRIPTION
This swaps out the nsqd env variable for the nsqlookupd
variable. This may... or may not help things. The conversation with the lookups does not happen every time a message is being worked with, only on first connection and if something goes wrong.
Considering the way we use producers as single purpose things, this might have to talk to lookup every time we want to write a message which could introduce some latency issues.

The producer should now get, from the lookup, the nsqd that is ready for its
message.

HYD-1505