### PR TITLE
Wait for Producer to connect.

### DIFF
--- a/lib/fastly_nsq/fake_backend.rb
+++ b/lib/fastly_nsq/fake_backend.rb
@@ -36,6 +36,10 @@ module FastlyNsq
       def initialize(topic:, nsqlookupd: nil, tls_v1: nil, tls_options: nil)
       end
 
+      def connected?
+        true
+      end
+
       def write(string)
         message = Message.new(string)
         queue.push(message)

--- a/lib/fastly_nsq/producer.rb
+++ b/lib/fastly_nsq/producer.rb
@@ -10,6 +10,7 @@ module FastlyNsq
       @topic       = topic
       @tls_options = TlsOptions.as_hash(tls_options)
       @connector   = connector
+      sleep(0.5) until connection.connected?
     end
 
     private

--- a/lib/fastly_nsq/producer.rb
+++ b/lib/fastly_nsq/producer.rb
@@ -10,7 +10,9 @@ module FastlyNsq
       @topic       = topic
       @tls_options = TlsOptions.as_hash(tls_options)
       @connector   = connector
-      sleep(0.1) until connection.connected?
+      Timeout.timeout(5) do
+        sleep(0.1) until connection.connected?
+      end
     end
 
     private

--- a/lib/fastly_nsq/producer.rb
+++ b/lib/fastly_nsq/producer.rb
@@ -10,7 +10,7 @@ module FastlyNsq
       @topic       = topic
       @tls_options = TlsOptions.as_hash(tls_options)
       @connector   = connector
-      sleep(0.5) until connection.connected?
+      sleep(0.1) until connection.connected?
     end
 
     private

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.9.2'.freeze
+  VERSION = '0.9.3'.freeze
 end

--- a/spec/lib/fastly_nsq/producer_spec.rb
+++ b/spec/lib/fastly_nsq/producer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FastlyNsq::Producer do
   let(:producer) { FastlyNsq::Producer.new(topic: topic) }
 
   describe 'when connector connects to a backend Producer' do
-    let(:backend)   { instance_double FastlyNsq::FakeBackend::Producer, write: nil, terminate: nil }
+    let(:backend)   { instance_double FastlyNsq::FakeBackend::Producer, write: nil, terminate: nil, connected?: true }
     let(:connector) { double 'Connector', new: backend }
     let(:producer) do
       FastlyNsq::Producer.new topic: topic, connector: connector
@@ -31,6 +31,10 @@ RSpec.describe FastlyNsq::Producer do
 
         def new(*_)
           self
+        end
+
+        def connected?
+          true
         end
 
         def terminate


### PR DESCRIPTION
When working with a `Producer` over `nsqlookupd`'s, there is a very short time where the Thread that attempts to establish connections might not have found one yet. In the case we have before this PR, we are always going to run into this problem with the first `.write` we make as we lazily make the `Producer` and then call `.write` straight away.

This changes our initializer to be less lazy AND has it wait until the `Producer` believes it is "connected".