### PR TITLE
catch, log, and terminate to ensure producer dies

### DIFF
--- a/lib/fastly_nsq/producer.rb
+++ b/lib/fastly_nsq/producer.rb
@@ -15,7 +15,7 @@ module FastlyNsq
       end
     rescue Timeout::Error => error
       logger.error "Producer for #{topic} failed to connect!"
-      @connection.terminate
+      connection.terminate
       raise error
     end
 

--- a/lib/fastly_nsq/producer.rb
+++ b/lib/fastly_nsq/producer.rb
@@ -13,6 +13,10 @@ module FastlyNsq
       Timeout.timeout(5) do
         sleep(0.1) until connection.connected?
       end
+    rescue Timeout::Error => error
+      logger.error "Producer for #{topic} failed to connect!"
+      @connection.terminate
+      raise error
     end
 
     private

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.9.3'.freeze
+  VERSION = '0.9.4'.freeze
 end


### PR DESCRIPTION
The Timeout in Producer was leaving open the connection it has just
made in the case of it timing out waiting for a the connection to
connect... This will catch the timeout, terminate the connection,
log the issue, and re-raise the error.