### PR TITLE
Consumer should connect on initialize

### DIFF
--- a/lib/fastly_nsq/consumer.rb
+++ b/lib/fastly_nsq/consumer.rb
@@ -13,6 +13,13 @@ module FastlyNsq
       @channel     = channel
       @tls_options = TlsOptions.as_hash(tls_options)
       @connector   = connector
+      Timeout.timeout(5) do
+        sleep(0.1) until connection.connected?
+      end
+    rescue Timeout::Error => error
+      FastlyNsq.logger.error "Consumer for #{topic} failed to connect!"
+      connection.terminate
+      raise error
     end
 
     private

--- a/lib/fastly_nsq/fake_backend.rb
+++ b/lib/fastly_nsq/fake_backend.rb
@@ -60,6 +60,10 @@ module FastlyNsq
       def initialize(nsqlookupd: nil, topic:, channel:, tls_v1: nil, tls_options: nil)
       end
 
+      def connected?
+        true
+      end
+
       def pop(delay = FakeBackend.delay)
         message = nil
 

--- a/lib/fastly_nsq/producer.rb
+++ b/lib/fastly_nsq/producer.rb
@@ -14,7 +14,7 @@ module FastlyNsq
         sleep(0.1) until connection.connected?
       end
     rescue Timeout::Error => error
-      logger.error "Producer for #{topic} failed to connect!"
+      FastlyNsq.logger.error "Producer for #{topic} failed to connect!"
       connection.terminate
       raise error
     end

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.9.4'.freeze
+  VERSION = '0.9.5'.freeze
 end

--- a/spec/lib/fastly_nsq/consumer_spec.rb
+++ b/spec/lib/fastly_nsq/consumer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FastlyNsq::Consumer do
   let(:consumer) { FastlyNsq::Consumer.new topic: topic, channel: channel }
 
   describe 'when connected to a backend Consumer' do
-    let(:backend)   { instance_double FastlyNsq::FakeBackend::Consumer, pop: nil, pop_without_blocking: nil, size: nil, terminate: nil }
+    let(:backend)   { instance_double FastlyNsq::FakeBackend::Consumer, pop: nil, pop_without_blocking: nil, size: nil, terminate: nil, connected?: true }
     let(:connector) { double 'Connector strategy', new: backend }
 
     let(:consumer) do
@@ -43,6 +43,10 @@ RSpec.describe FastlyNsq::Consumer do
 
         def new(*_)
           self
+        end
+
+        def connected?
+          true
         end
 
         def terminate


### PR DESCRIPTION
* fixes bug in FastlyNsq::Producer when calling `logger`
* ensures that the consumer's connection to `nsq` is created on initialization.

Recommended Reviewers
=====================
@fastly/billing
