### PR TITLE
Add topic to listener log lines.

### DIFF
--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -85,7 +85,7 @@ module FastlyNsq
     private
 
     def log(message)
-      @logger.info "[NSQ] Message Received: #{message}" if @logger
+      @logger.info "[NSQ] Message received on topic [#{@topic}]: #{message}" if @logger
     end
 
     def cleanup

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.10.0'.freeze
+  VERSION = '0.10.1'.freeze
 end

--- a/spec/lib/fastly_nsq/listener_spec.rb
+++ b/spec/lib/fastly_nsq/listener_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe FastlyNsq::Listener do
       allow(logger).to receive(:info)
       listener.go run_once: true
 
-      expect(logger).to have_received(:info).once.with(/\[NSQ\] Message Received: #{message.body}/)
+      expect(logger).to have_received(:info).once.with(/\[NSQ\] Message received on topic \[#{topic}\]: #{message.body}/)
     end
 
     context 'when preprocessor is provided' do


### PR DESCRIPTION
Reason for Change
===================
* The will make parsing logs much easier 

In the future I wonder if we want to change this log line to `.debug` or make it configurable. When pushing a large volume of messages the logs get rather large. And in most cases I wonder if it wouldn't be better to configure this in the listener rake tasks inside the message processor as part of the application so that we only log the parts we want rather than the entire message.

List of Changes
===============
* add [topic] to the message received log lines in the listener.

Recommended Reviewers
=====================
@fastly/billing