### PR TITLE
Add accessor for Nsq::Message object and delegate methods

### DIFF
--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -94,8 +94,9 @@ module FastlyNsq
     end
 
     def next_message
-      message = @consumer.pop # TODO: consumer.pop do |message|
-      result  = yield FastlyNsq::Message.new(message)
+      nsq_message = @consumer.pop # TODO: consumer.pop do |message|
+      message = FastlyNsq::Message.new(nsq_message)
+      result  = yield message
       message.finish if result
     end
 

--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -95,7 +95,7 @@ module FastlyNsq
 
     def next_message
       message = @consumer.pop # TODO: consumer.pop do |message|
-      result  = yield FastlyNsq::Message.new(message.body)
+      result  = yield FastlyNsq::Message.new(message)
       message.finish if result
     end
 

--- a/lib/fastly_nsq/message.rb
+++ b/lib/fastly_nsq/message.rb
@@ -3,9 +3,9 @@ require 'json'
 class FastlyNsq::Message
   extend Forwardable
 
-  def_delegators :@nsq_message, :attempts, :finish, :requeue, :touch, :timestamp
+  def_delegators :@nsq_message, :attempts, :touch, :timestamp
 
-  attr_reader :nsq_message, :raw_body
+  attr_reader :managed, :nsq_message, :raw_body
   alias to_s raw_body
 
   def initialize(nsq_message)
@@ -19,5 +19,17 @@ class FastlyNsq::Message
 
   def body
     @body ||= JSON.parse(raw_body)
+  end
+
+  def finish
+    result = nsq_message.finish unless managed
+    @managed = true
+    result
+  end
+
+  def requeue(*args)
+    result = nsq_message.requeue(*args) unless managed
+    @managed = true
+    result
   end
 end

--- a/lib/fastly_nsq/message.rb
+++ b/lib/fastly_nsq/message.rb
@@ -22,14 +22,16 @@ class FastlyNsq::Message
   end
 
   def finish
-    result = nsq_message.finish unless managed
-    @managed = true
-    result
+    return managed if managed
+
+    @managed = :finished
+    nsq_message.finish
   end
 
   def requeue(*args)
-    result = nsq_message.requeue(*args) unless managed
-    @managed = true
-    result
+    return managed if managed
+
+    @managed = :requeued
+    nsq_message.requeue(*args)
   end
 end

--- a/lib/fastly_nsq/message.rb
+++ b/lib/fastly_nsq/message.rb
@@ -1,11 +1,16 @@
 require 'json'
 
 class FastlyNsq::Message
-  attr_reader :raw_body
+  extend Forwardable
+
+  def_delegators :@nsq_message, :attempts, :finish, :requeue, :touch, :timestamp
+
+  attr_reader :nsq_message, :raw_body
   alias to_s raw_body
 
-  def initialize(raw_body)
-    @raw_body = raw_body
+  def initialize(nsq_message)
+    @nsq_message = nsq_message
+    @raw_body = nsq_message.body
   end
 
   def data

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.10.1'.freeze
+  VERSION = '0.11.0'.freeze
 end

--- a/spec/lib/fastly_nsq/message_spec.rb
+++ b/spec/lib/fastly_nsq/message_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe FastlyNsq::Message do
     subject.requeue(1000)
     subject.finish
 
-    expect(subject.managed).to be(true)
+    expect(subject.managed).to eq(:requeued)
   end
 
   it 'does not requeue if the message was finished' do
@@ -49,6 +49,6 @@ RSpec.describe FastlyNsq::Message do
     subject.finish
     subject.requeue
 
-    expect(subject.managed).to be(true)
+    expect(subject.managed).to eq(:finished)
   end
 end

--- a/spec/lib/fastly_nsq/message_spec.rb
+++ b/spec/lib/fastly_nsq/message_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 require 'json'
 
 RSpec.describe FastlyNsq::Message do
-  let(:body)      { { 'data' => 'goes here', 'other_field' => 'is over here' } }
-  let(:json_body) { body.to_json }
-  subject         { FastlyNsq::Message.new json_body }
+  let(:nsq_message) { double 'Nsq::Message', body: json_body, attempts: nil, finish: nil, requeue: nil, touch: nil, timestamp: nil }
+  let(:body)        { { 'data' => 'goes here', 'other_field' => 'is over here' } }
+  let(:json_body)   { body.to_json }
+  subject           { FastlyNsq::Message.new nsq_message }
 
   it 'preserves original message body as raw_body' do
     expect(subject.raw_body).to eq(json_body)
@@ -20,5 +21,13 @@ RSpec.describe FastlyNsq::Message do
 
   it 'aliases raw_body to to_s' do
     expect(subject.to_s).to eq(json_body)
+  end
+
+  it 'delegates methods to the nsq_message object' do
+    %w(attempts finish requeue touch timestamp).each do |method|
+      expect(nsq_message).to receive(method)
+
+      subject.send(method)
+    end
   end
 end

--- a/spec/lib/fastly_nsq/message_spec.rb
+++ b/spec/lib/fastly_nsq/message_spec.rb
@@ -25,9 +25,30 @@ RSpec.describe FastlyNsq::Message do
 
   it 'delegates methods to the nsq_message object' do
     %w(attempts finish requeue touch timestamp).each do |method|
+      subject = FastlyNsq::Message.new nsq_message
       expect(nsq_message).to receive(method)
 
       subject.send(method)
     end
+  end
+
+  it 'does not finish if the message was requeued' do
+    expect(nsq_message).to receive(:requeue).with(1000)
+    expect(nsq_message).not_to receive(:finish)
+
+    subject.requeue(1000)
+    subject.finish
+
+    expect(subject.managed).to be(true)
+  end
+
+  it 'does not requeue if the message was finished' do
+    expect(nsq_message).to receive(:finish)
+    expect(nsq_message).not_to receive(:requeue)
+
+    subject.finish
+    subject.requeue
+
+    expect(subject.managed).to be(true)
   end
 end


### PR DESCRIPTION
Reason for Change
===================
* We'd like to be able to requeue jobs in NSQ vs just dumping them into Sidekiq

List of Changes
===============
* Change the initialization of `FastlyNsq::Message` to accept the `Nsq::Message` instead of just the body.
* add `Forwardable` and delegate methods to Nsq::Message. https://github.com/wistia/nsq-ruby/blob/50f943cf7b58f9d2b4c071accaf46658597d89a2/lib/nsq/frames/message.rb


Risks
=====
* Low. The initialization changes but the public interface remains the same.

Recommended Reviewers
=====================
@fastly/billing