### PR TITLE
Cleanup in the terminate and kill methods

### DIFF
--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -61,8 +61,6 @@ module FastlyNsq
     rescue Exception => ex # rubocop:disable Lint/RescueException
       @logger.error ex.inspect
       @manager.listener_killed(self)
-    ensure
-      cleanup
     end
 
     def status
@@ -71,12 +69,14 @@ module FastlyNsq
 
     def terminate
       @done = true
+      cleanup
       return unless @thread
       @logger.info "< Listener TERM: topic #{@topic}"
     end
 
     def kill
       @done = true
+      cleanup
       return unless @thread
       @logger.info "< Listener KILL: topic #{@topic}"
       @thread.raise FastlyNsq::Shutdown
@@ -90,7 +90,7 @@ module FastlyNsq
 
     def cleanup
       @consumer.terminate
-      @logger.info '< Consumer terminated'
+      @logger.info "< Consumer terminated: topic [#{@topic}]"
     end
 
     def next_message

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.12.0'.freeze
+  VERSION = '0.12.1'.freeze
 end

--- a/spec/lib/fastly_nsq/listener_spec.rb
+++ b/spec/lib/fastly_nsq/listener_spec.rb
@@ -168,10 +168,13 @@ RSpec.describe FastlyNsq::Listener do
         listener.start
         state = listener.instance_variable_get(:@done)
         expect(state).to eq false
+        consumer = listener.instance_variable_get(:@consumer)
+        allow(consumer).to receive(:terminate)
         listener.terminate
 
         state = listener.instance_variable_get(:@done)
         expect(logger).to have_received(:info).thrice
+        expect(consumer).to have_received(:terminate)
         expect(state).to eq true
       end
 
@@ -179,10 +182,13 @@ RSpec.describe FastlyNsq::Listener do
         listener.start
         state = listener.instance_variable_get(:@done)
         expect(state).to eq false
+        consumer = listener.instance_variable_get(:@consumer)
+        allow(consumer).to receive(:terminate)
         listener.kill
 
         state = listener.instance_variable_get(:@done)
         expect(logger).to have_received(:info).thrice
+        expect(consumer).to have_received(:terminate)
         expect(thread).to have_received(:raise).with(FastlyNsq::Shutdown)
         expect(state).to eq true
       end

--- a/spec/lib/fastly_nsq/listener_spec.rb
+++ b/spec/lib/fastly_nsq/listener_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe FastlyNsq::Listener do
         listener.terminate
 
         state = listener.instance_variable_get(:@done)
-        expect(logger).to have_received(:info).twice
+        expect(logger).to have_received(:info).thrice
         expect(state).to eq true
       end
 
@@ -182,7 +182,7 @@ RSpec.describe FastlyNsq::Listener do
         listener.kill
 
         state = listener.instance_variable_get(:@done)
-        expect(logger).to have_received(:info).twice
+        expect(logger).to have_received(:info).thrice
         expect(thread).to have_received(:raise).with(FastlyNsq::Shutdown)
         expect(state).to eq true
       end


### PR DESCRIPTION
This means that a listener will not ensure it has its connections
terminated anymore but the manager will still do so when appropriate.

Before we where killing terminating the consumer whenever any error occured
and never re-creating it...

This has potential to make the consumer connection live on in some bad cases.
The alternative would be to re-create the Consumer whenever we need to
dup_and_reset.