### PR TITLE
Only raise if consumer is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ block. An exmaple of this can be found here: [`Example Config`](exmaple_config_c
 
 An example of using the cli:
 ```bash
-./bin/fastly_nsq -r ./example_config_class.rb -L ./test.log -P ./fastly_nsq.pid -v -d
+./bin/fastly_nsq -r ./example_config_class.rb -L ./test.log -P ./fastly_nsq.pid -v -d -t 4
 ```
 
 ### FastlyNsq::Messgener

--- a/lib/fastly_nsq/cli.rb
+++ b/lib/fastly_nsq/cli.rb
@@ -92,6 +92,10 @@ class FastlyNsq::CLI
       o.on '-v', '--verbose', 'enable verbose logging output' do |arg|
         opts[:verbose] = arg
       end
+
+      o.on '-t', '--timeout SECONDS', 'shutdown deadline timeout' do |arg|
+        opts[:timeout] = arg
+      end
     end
 
     @parser.banner = 'fastly_nsq [options]'

--- a/lib/fastly_nsq/consumer.rb
+++ b/lib/fastly_nsq/consumer.rb
@@ -22,6 +22,10 @@ module FastlyNsq
       raise error
     end
 
+    def empty?
+      @connection.size == 0 # rubocop:disable ZeroLengthPredicate
+    end
+
     private
 
     attr_reader :channel, :topic, :tls_options

--- a/lib/fastly_nsq/fake_backend.rb
+++ b/lib/fastly_nsq/fake_backend.rb
@@ -83,6 +83,10 @@ module FastlyNsq
         queue.size
       end
 
+      def empty?
+        queue.empty?
+      end
+
       def terminate
         # noop
       end

--- a/lib/fastly_nsq/launcher.rb
+++ b/lib/fastly_nsq/launcher.rb
@@ -24,7 +24,7 @@ class FastlyNsq::Launcher
   # return until all work is complete and cleaned up.
   # It can take up to the timeout to complete.
   def stop
-    deadline = Time.now + @options.fetch(:timeout, 10)
+    deadline = Time.now + @options.fetch(:timeout, 5)
     quiet
     @manager.stop deadline
   end

--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -72,7 +72,8 @@ module FastlyNsq
       cleanup
       return unless @thread
       @logger.info "< Listener TERM: topic #{@topic}"
-      @thread.raise FastlyNsq::Shutdown
+      # Interrupt a Consumer blocking in pop with no messages otherwise it will never shutdown
+      @thread.raise FastlyNsq::Shutdown if @consumer.empty?
     end
 
     def kill

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.12.2'.freeze
+  VERSION = '0.12.3'.freeze
 end

--- a/spec/lib/fastly_nsq/launcher_spec.rb
+++ b/spec/lib/fastly_nsq/launcher_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FastlyNsq::Launcher do
   let(:launcher) { FastlyNsq::Launcher.new options }
   let(:manager)  { instance_double 'Manager', start: nil, quiet: nil, stop: nil }
   let(:thread)   { instance_double 'Thread' }
-  let(:options)  { { joe: 'biden' } }
+  let(:options)  { { joe: 'biden', timeout: 9 } }
 
   before do
     allow(FastlyNsq::Manager).to receive(:new).and_return(manager)
@@ -44,7 +44,7 @@ RSpec.describe FastlyNsq::Launcher do
       now = Time.now
       allow(Time).to receive(:now).and_return(now)
       launcher.stop
-      expect(manager).to have_received(:stop).with(now + 10)
+      expect(manager).to have_received(:stop).with(now + options[:timeout])
     end
 
     it 'quites the manager' do

--- a/spec/lib/fastly_nsq/listener_spec.rb
+++ b/spec/lib/fastly_nsq/listener_spec.rb
@@ -178,6 +178,23 @@ RSpec.describe FastlyNsq::Listener do
         expect(state).to eq true
       end
 
+      it 'raise in terminate to interupt blocking on an empty queue' do
+        listener.start
+        listener.terminate
+
+        expect(consumer.empty?).to be true
+        expect(thread).to have_received(:raise)
+      end
+
+      it 'terminate allows messages to be completed' do
+        100.times { FastlyNsq::Messenger.deliver(on_topic: topic, message: 'test_message') }
+        listener.start
+        listener.terminate
+
+        expect(consumer.empty?).to be false
+        expect(thread).to_not have_received(:raise)
+      end
+
       it 'can be killed' do
         listener.start
         state = listener.instance_variable_get(:@done)


### PR DESCRIPTION
Terminate should allow a consumer to attempt to finish the work that it is
doing. We want it to finish the message it is on and then on the next pass
of the loop, see that @done is set and finish up. However, if there are no
messages, consumer.pop will be blocking and will never find out that @done
is set. We will hit the stop deadline and end up calling kill. Here we are
adding a check to see if the consumer is empty, and only if it is do we
raise to get it out from being stuck on a pop. Otherwise, we allow it to
finish the work it is on and findout that
@done is set ...