### PR TITLE
fix: store topic on produced mock message

### DIFF
--- a/lib/fastly_nsq/fake_backend.rb
+++ b/lib/fastly_nsq/fake_backend.rb
@@ -33,7 +33,10 @@ module FastlyNsq
     end
 
     class Producer
-      def initialize(topic:, nsqlookupd: nil, tls_v1: nil, tls_options: nil)
+      attr_reader :topic
+
+      def initialize(topic:, **)
+        @topic = topic
       end
 
       def connected?
@@ -41,7 +44,7 @@ module FastlyNsq
       end
 
       def write(string)
-        message = Message.new(string)
+        message = Message.new(string, topic: topic)
         queue.push(message)
       end
 
@@ -57,8 +60,7 @@ module FastlyNsq
     end
 
     class Consumer
-      def initialize(nsqlookupd: nil, topic:, channel:, tls_v1: nil, tls_options: nil)
-      end
+      def initialize(nsqlookupd: nil, topic:, channel:, tls_v1: nil, tls_options: nil); end
 
       def connected?
         true
@@ -99,14 +101,14 @@ module FastlyNsq
     end
 
     class Message
-      attr_reader :body
+      attr_reader :topic, :body
 
-      def initialize(body)
+      def initialize(body, topic: nil)
+        @topic = topic
         @body = body
       end
 
-      def finish
-      end
+      def finish; end
     end
   end
 end

--- a/spec/lib/fastly_nsq/fake_backend_spec.rb
+++ b/spec/lib/fastly_nsq/fake_backend_spec.rb
@@ -41,9 +41,16 @@ RSpec.describe FastlyNsq::FakeBackend::Producer do
   let(:producer) { FastlyNsq::FakeBackend::Producer.new topic: topic }
 
   it 'adds a new message to the queue' do
-    producer.write('hello')
+    body = 'hello'
 
-    expect(FastlyNsq::FakeBackend.queue.size).to eq 1
+    expect do
+      producer.write(body)
+    end.to change { FastlyNsq::FakeBackend.queue.size }.by(1)
+
+    message = FastlyNsq::FakeBackend.queue.shift
+
+    expect(message.topic).to eq(topic)
+    expect(message.body).to eq(body)
   end
 
   it 'has a `terminate` method which is a noop' do


### PR DESCRIPTION
Reason for Change
===================

Storing the topic on `FastlyNsq::FakeBackend::Message` allows for
stronger assertions without the use of stubbing.

List of Changes
===============
* Store `topic` on `FastlyNsq::FakeBackend::Producer`
* Set `topic` on `FastlyNsq::FakeBackend::Message` on
`FastlyNsq::FakeBackend::Producer#write`

Risks
=====

I see no potential risk.

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing