### PR TITLE
To rubocop update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,9 +26,6 @@ GuardClause:
 IfUnlessModifier:
   Enabled: false
 
-ClassLength:
-  Enabled: false
-
 Style/ClassVars:
   Description: 'Avoid the use of class variables.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,9 +10,6 @@ AllCops:
 LineLength:
   Enabled: false
 
-CollectionMethods:
-  Enabled: false
-
 CyclomaticComplexity:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   Exclude:
     - 'db/schema.rb'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
 
 LineLength:
   Enabled: false
@@ -70,3 +70,6 @@ Style/TrailingCommaInLiteral:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
   Enabled: true
+
+Lint/RescueWithoutErrorClass:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,9 +10,6 @@ AllCops:
 LineLength:
   Enabled: false
 
-HashSyntax:
-  Enabled: false
-
 BracesAroundHashParameters:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,9 +10,6 @@ AllCops:
 LineLength:
   Enabled: false
 
-BracesAroundHashParameters:
-  Enabled: false
-
 CollectionMethods:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,9 +10,6 @@ AllCops:
 LineLength:
   Enabled: false
 
-CyclomaticComplexity:
-  Enabled: true
-
 Style/DotPosition:
   Enabled: true
   EnforcedStyle: trailing

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,6 @@ AllCops:
     - 'Gemfile'
   TargetRubyVersion: 2.2
 
-LineLength:
-  Enabled: false
-
 Layout/DotPosition:
   Enabled: true
   EnforcedStyle: trailing
@@ -17,13 +14,19 @@ Layout/DotPosition:
     - leading
     - trailing
 
-MethodLength:
+Lint/RescueWithoutErrorClass:
   Enabled: false
 
-GuardClause:
+Metrics/MethodLength:
   Enabled: false
 
-IfUnlessModifier:
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/BlockLength:
+  ExcludedMethods: [describe, context, configure]
+
+Style/ClassAndModuleChildren:
   Enabled: false
 
 Style/ClassVars:
@@ -31,28 +34,25 @@ Style/ClassVars:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'
   Enabled: false
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
-RegexpLiteral:
+Style/GuardClause:
   Enabled: false
 
-SignalException:
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/SignalException:
   EnforcedStyle: only_raise
-
-Style/ClassAndModuleChildren:
-  Enabled: false
-
-Style/TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: comma
-  Enabled: true
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
   Enabled: true
 
-Lint/RescueWithoutErrorClass:
-  Enabled: false
-
-Metrics/BlockLength:
-  ExcludedMethods: [describe, context, configure]
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
     - 'db/schema.rb'
     - 'vendor/**/*'
+    - 'Gemfile'
   TargetRubyVersion: 2.2
 
 LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,3 +74,6 @@ Style/TrailingCommaInArguments:
 
 Lint/RescueWithoutErrorClass:
   Enabled: false
+
+Metrics/BlockLength:
+  ExcludedMethods: [describe, context, configure]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,9 +20,6 @@ Style/DotPosition:
 MethodLength:
   Enabled: false
 
-PerlBackrefs:
-  Enabled: false
-
 RescueModifier:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,9 +20,6 @@ Style/DotPosition:
 MethodLength:
   Enabled: false
 
-RescueModifier:
-  Enabled: false
-
 GuardClause:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
 LineLength:
   Enabled: false
 
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: true
   EnforcedStyle: trailing
   SupportedStyles:

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ you might write your own processor.
 * Thomas O'Neil ([@alieander](https://github.com/alieander))
 * Joshua Wehner ([@jaw6](https://github.com/jaw6))
 * Lukas Eklund  ([@leklund](https://github.com/leklund))
+* Josh Lane     ([@lanej](https://github.com/lanej))
 
 ## Acknowledgements
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'rubygems'
 
 begin

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ require 'bundler/audit/cli'
 namespace :bundler do
   desc 'Updates the ruby-advisory-db and runs audit'
   task :audit do
-    %w(update check).each do |command|
+    %w[update check].each do |command|
       Bundler::Audit::CLI.start [command]
     end
   end

--- a/example_config_class.rb
+++ b/example_config_class.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class MessageProcessor
   def self.process(message)
     FastlyNsq.logger.info("IN PROCESS: #{message}")

--- a/examples/Rakefile
+++ b/examples/Rakefile
@@ -24,7 +24,7 @@ end
 #-------------------------------------------------------------------------------
 # In Rails, you can include the application environment. The task looks like:
 
-FastlyNsq::RakeTask.new(:listen_task => :environment)
+FastlyNsq::RakeTask.new(listen_task: :environment)
 
 #-------------------------------------------------------------------------------
 # It's also possible to define the rake task to allow for overriding channel

--- a/examples/Rakefile
+++ b/examples/Rakefile
@@ -30,7 +30,7 @@ FastlyNsq::RakeTask.new(:listen_task => :environment)
 # It's also possible to define the rake task to allow for overriding channel
 # and topics when calling the rake task:
 
-FastlyNsq::RakeTask.new(:listen_task, [:channel, :topics])
+FastlyNsq::RakeTask.new(:listen_task, %i[channel topics])
 
 # Then call the task:
 #   rake listen_task[my_channel, {topic: Processor}]
@@ -38,4 +38,4 @@ FastlyNsq::RakeTask.new(:listen_task, [:channel, :topics])
 #-------------------------------------------------------------------------------
 # Do the same thing and include the environment:
 
-FastlyNsq::RakeTask.new(:listen_task, [:channel, :topics] => :environment)
+FastlyNsq::RakeTask.new(:listen_task, %i[channel topics] => :environment)

--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.files         = `git ls-files`.split("\n")
 
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|features)/})
   gem.require_paths = ['lib']
 
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 11.1.2'
   gem.add_development_dependency 'rdoc', '~> 4.2.2'
   gem.add_development_dependency 'rspec', '~> 3.4.0'
-  gem.add_development_dependency 'rubocop', '~> 0.39.0'
+  gem.add_development_dependency 'rubocop', '~> 0.51.0'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
   gem.add_development_dependency 'webmock'
 

--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fastly_nsq/version'

--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -10,9 +10,9 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Fastly NSQ Adapter'
   gem.description   = "Helper classes for Fastly's NSQ Services"
   gem.license       = 'MIT'
-  gem.authors       = ["Tommy O'Neil", 'Adarsh Pandit', 'Joshua Wehner', 'Lukas Eklund']
+  gem.authors       = ["Tommy O'Neil", 'Adarsh Pandit', 'Joshua Wehner', 'Lukas Eklund', 'Josh Lane']
   gem.email         = 'tommy@fastly.com'
-  gem.homepage      = 'https://github.com/fastly/fastly-nsq'
+  gem.homepage      = 'https://github.com/fastly/fastly_nsq'
 
   gem.files         = `git ls-files`.split("\n")
 

--- a/lib/fastly_nsq/cli.rb
+++ b/lib/fastly_nsq/cli.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 $stdout.sync = true
 
 require 'fastly_nsq'

--- a/lib/fastly_nsq/cli.rb
+++ b/lib/fastly_nsq/cli.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 $stdout.sync = true
 
 require 'fastly_nsq'
@@ -250,3 +251,4 @@ class FastlyNsq::CLI
     options[:pidfile]
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/lib/fastly_nsq/cli.rb
+++ b/lib/fastly_nsq/cli.rb
@@ -120,7 +120,7 @@ class FastlyNsq::CLI
   def pid_status(pidfile)
     return :exited unless File.exist?(pidfile)
     pid = ::File.read(pidfile).to_i
-    return :dead if pid == 0
+    return :dead if pid.zero?
     Process.kill(0, pid) # check process status
     :running
   rescue Errno::ESRCH
@@ -151,7 +151,7 @@ class FastlyNsq::CLI
 
   def trap_signals
     self_read, self_write = IO.pipe
-    sigs = %w(INT TERM TTIN USR1)
+    sigs = %w[INT TERM TTIN USR1]
 
     sigs.each do |sig|
       begin

--- a/lib/fastly_nsq/consumer.rb
+++ b/lib/fastly_nsq/consumer.rb
@@ -17,7 +17,7 @@ module FastlyNsq
     end
 
     def empty?
-      connection.size.zero? # rubocop:disable ZeroLengthPredicate
+      connection.size.zero?
     end
 
     private

--- a/lib/fastly_nsq/consumer.rb
+++ b/lib/fastly_nsq/consumer.rb
@@ -17,7 +17,7 @@ module FastlyNsq
     end
 
     def empty?
-      connection.size == 0 # rubocop:disable ZeroLengthPredicate
+      connection.size.zero? # rubocop:disable ZeroLengthPredicate
     end
 
     private

--- a/lib/fastly_nsq/http/nsqd.rb
+++ b/lib/fastly_nsq/http/nsqd.rb
@@ -9,7 +9,7 @@ class FastlyNsq::Http
     def_delegator :client, :post
 
     BASE_NSQD_URL = ENV.fetch 'NSQD_URL', "https://#{ENV.fetch('NSQD_HTTPS_ADDRESS', '')}"
-    VALID_FORMATS = %w(text json).freeze
+    VALID_FORMATS = %w[text json].freeze
 
     ##
     # Monitoring endpoint, should return 200 OK. It returns an HTTP 500 if it is not healthy.

--- a/lib/fastly_nsq/launcher.rb
+++ b/lib/fastly_nsq/launcher.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'fastly_nsq/safe_thread'
 
 class FastlyNsq::Launcher

--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'fastly_nsq/message'
 require 'fastly_nsq/manager'
 require 'fastly_nsq/safe_thread'

--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -58,8 +58,8 @@ module FastlyNsq
       @manager.listener_stopped(self)
     rescue FastlyNsq::Shutdown
       @manager.listener_stopped(self)
-    rescue Exception => ex # rubocop:disable Lint/RescueException
-      @logger.error ex.inspect
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      @logger.error e.inspect
       @manager.listener_killed(self)
     end
 

--- a/lib/fastly_nsq/listener/config.rb
+++ b/lib/fastly_nsq/listener/config.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module FastlyNsq
   class Listener
     class Config

--- a/lib/fastly_nsq/manager.rb
+++ b/lib/fastly_nsq/manager.rb
@@ -81,13 +81,11 @@ class FastlyNsq::Manager
   def setup_listener(topic, processor)
     FastlyNsq.logger.info { "Listening to topic:'#{topic}' on channel: '#{FastlyNsq.channel}'" }
     FastlyNsq::Listener.new(
-      {
-        topic:        topic,
-        channel:      FastlyNsq.channel,
-        processor:    processor,
-        preprocessor: FastlyNsq.preprocessor,
-        manager:      self,
-      },
+      topic:        topic,
+      channel:      FastlyNsq.channel,
+      processor:    processor,
+      preprocessor: FastlyNsq.preprocessor,
+      manager:      self,
     )
   end
 

--- a/lib/fastly_nsq/manager.rb
+++ b/lib/fastly_nsq/manager.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'set'
 
 class FastlyNsq::Manager

--- a/lib/fastly_nsq/safe_thread.rb
+++ b/lib/fastly_nsq/safe_thread.rb
@@ -9,10 +9,10 @@ module FastlyNsq::SafeThread
 
   def watchdog(last_words)
     yield
-  rescue => ex
-    FastlyNsq.logger.error ex
+  rescue => e
+    FastlyNsq.logger.error e
     FastlyNsq.logger.error last_words
-    FastlyNsq.logger.error ex.backtrace.join("\n") unless ex.backtrace.nil?
-    raise ex
+    FastlyNsq.logger.error e.backtrace.join("\n") unless e.backtrace.nil?
+    raise e
   end
 end

--- a/lib/fastly_nsq/safe_thread.rb
+++ b/lib/fastly_nsq/safe_thread.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module FastlyNsq::SafeThread
   def safe_thread(name, &block)
     Thread.new do

--- a/spec/lib/fastly_nsq/http/nsqd_spec.rb
+++ b/spec/lib/fastly_nsq/http/nsqd_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FastlyNsq::Http::Nsqd do
   let(:base_uri) { 'http://example.com' }
 
   it 'makes simple get requests' do
-    %w(ping info config/nsqlookupd_tcp_addresses).each do |api|
+    %w[ping info config/nsqlookupd_tcp_addresses].each do |api|
       url = "#{base_uri}/#{api}"
       stub_request(:get, url)
       FastlyNsq::Http::Nsqd.send(api.tr('/', '_').to_sym, base_uri: base_uri)
@@ -56,7 +56,7 @@ RSpec.describe FastlyNsq::Http::Nsqd do
   end
 
   it 'can create, delete, empty, pause and unpause topics and channels' do
-    verbs = %w(create delete empty pause unpause)
+    verbs = %w[create delete empty pause unpause]
 
     verbs.each do |verb|
       url = "#{base_uri}/topic/#{verb}?topic=lol"

--- a/spec/lib/fastly_nsq/http/nsqlookupd_spec.rb
+++ b/spec/lib/fastly_nsq/http/nsqlookupd_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FastlyNsq::Http::Nsqlookupd do
   let(:base_uri) { 'http://example.com' }
 
   it 'makes simple get requests' do
-    %w(topics nodes ping info).each do |api|
+    %w[topics nodes ping info].each do |api|
       url = "#{base_uri}/#{api}"
       stub_request(:get, url)
       FastlyNsq::Http::Nsqlookupd.send(api.to_sym, base_uri: base_uri)

--- a/spec/lib/fastly_nsq/manager_spec.rb
+++ b/spec/lib/fastly_nsq/manager_spec.rb
@@ -47,13 +47,11 @@ RSpec.describe FastlyNsq::Manager do
     it 'sets up each configured listener' do
       configed_topics.each do |t|
         expect(FastlyNsq::Listener).to have_received(:new).with(
-          {
-            channel:      FastlyNsq.channel,
-            manager:      manager,
-            preprocessor: FastlyNsq.preprocessor,
-            processor:    t[:klass],
-            topic:        t[:topic],
-          },
+          channel:      FastlyNsq.channel,
+          manager:      manager,
+          preprocessor: FastlyNsq.preprocessor,
+          processor:    t[:klass],
+          topic:        t[:topic],
         )
       end
     end

--- a/spec/lib/fastly_nsq/message_spec.rb
+++ b/spec/lib/fastly_nsq/message_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe FastlyNsq::Message do
   end
 
   it 'delegates methods to the nsq_message object' do
-    %w(attempts finish requeue touch timestamp).each do |method|
+    %w[attempts finish requeue touch timestamp].each do |method|
       subject = FastlyNsq::Message.new nsq_message
       expect(nsq_message).to receive(method)
 

--- a/spec/lib/fastly_nsq/rake_task_spec.rb
+++ b/spec/lib/fastly_nsq/rake_task_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe FastlyNsq::RakeTask do
       let(:listener) { class_double FastlyNsq::Listener, listen_to: nil }
 
       it 'configures via a block if one is given' do
-        FastlyNsq::RakeTask.new(:begin_listening, [:channel, :topics]) do |task|
+        FastlyNsq::RakeTask.new(:begin_listening, %i[channel topics]) do |task|
           task.channel  = channel
           task.topics   = topics
           task.listener = listener
@@ -80,7 +80,7 @@ RSpec.describe FastlyNsq::RakeTask do
       it 'prefers inline channel definition over block assignments' do
         new_channel = 'send_balloons_to_customer_service'
 
-        FastlyNsq::RakeTask.new(:begin_listening, [:channel, :topics]) do |task|
+        FastlyNsq::RakeTask.new(:begin_listening, %i[channel topics]) do |task|
           task.channel  = channel
           task.topics   = topics
           task.listener = listener
@@ -95,7 +95,7 @@ RSpec.describe FastlyNsq::RakeTask do
       it 'configures a listener for each topic if there are multiple' do
         topics = %w(foo bar baz quuz etc)
 
-        FastlyNsq::RakeTask.new(:begin_listening, [:channel, :topics, :listener])
+        FastlyNsq::RakeTask.new(:begin_listening, %i[channel topics listener])
         Rake::Task['begin_listening'].execute(channel: channel, topics: topics, listener: listener)
 
         topics.each do |(topic, processor)|

--- a/spec/lib/fastly_nsq/rake_task_spec.rb
+++ b/spec/lib/fastly_nsq/rake_task_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe FastlyNsq::RakeTask do
       end
 
       it 'configures a listener for each topic if there are multiple' do
-        topics = %w(foo bar baz quuz etc)
+        topics = %w[foo bar baz quuz etc]
 
         FastlyNsq::RakeTask.new(:begin_listening, %i[channel topics listener])
         Rake::Task['begin_listening'].execute(channel: channel, topics: topics, listener: listener)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,7 @@ RSpec.configure do |config|
   def load_sample_environment_variables
     env_file = File.open('env_configuration_for_local_gem_tests.yml')
 
-    YAML.load(env_file).each do |key, value|
+    YAML.safe_load(env_file).each do |key, value|
       ENV[key.to_s] = value
     end
   end


### PR DESCRIPTION
Reason for Change
===================
There is a vulnerability in the version on rubocop we are using I guess.

List of Changes
===============
* update the version of rubocop to the latest release version (0.51.0)
* fix all new things that rubocop now finds offensive
* ignore some of the things rubocop finds offensive
* remove a bunch of cop configurations that did not actually affect the repo
* cleanup
* Add `Josh Lane` to the authors

Risks
=====
No Risks.
