### PR TITLE
Set metadata

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+### 0.13.1 / 2017-11-30
+
+* Allow specifying custom metadata on message delivery
+
 ### 0.12.3 / 2017-11-02
 
 * Remove initialization Timeout on Consumer Connections

--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ Wrapper around a producer for sending messages and persisting producer objects.
 FastlyNsq::Messenger.deliver(message: msg, on_topic: 'my_topic', originating_service: 'my service')
 ```
 
+You can also optionally pass custom metadata.
+
+```ruby
+FastlyNsq::Messenger.deliver(message: msg, on_topic: 'my_topic', originating_service: 'my service', meta: { test: 'test' })
+```
+
 This will use a FastlyNsq::Producer for the given topic or create on if it isn't
 already persisted. Then it will write the passed message to the queue. If you don't set
 the originating service it will use `unknown`

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ you might write your own processor.
 * Joshua Wehner ([@jaw6](https://github.com/jaw6))
 * Lukas Eklund  ([@leklund](https://github.com/leklund))
 * Josh Lane     ([@lanej](https://github.com/lanej))
+* Hassan Shahid ([@set5think](https://github.com/set5think))
 
 ## Acknowledgements
 

--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Fastly NSQ Adapter'
   gem.description   = "Helper classes for Fastly's NSQ Services"
   gem.license       = 'MIT'
-  gem.authors       = ["Tommy O'Neil", 'Adarsh Pandit', 'Joshua Wehner', 'Lukas Eklund', 'Josh Lane']
+  gem.authors       = ["Tommy O'Neil", 'Adarsh Pandit', 'Joshua Wehner', 'Lukas Eklund', 'Josh Lane', 'Hassan Shahid']
   gem.email         = 'tommy@fastly.com'
   gem.homepage      = 'https://github.com/fastly/fastly_nsq'
 

--- a/lib/fastly_nsq/messenger.rb
+++ b/lib/fastly_nsq/messenger.rb
@@ -4,12 +4,12 @@ module FastlyNsq::Messenger
 
   module_function
 
-  def deliver(message:, on_topic:, originating_service: nil)
+  def deliver(message:, on_topic:, originating_service: nil, meta: {})
+    meta[:originating_service] = originating_service || self.originating_service
+
     payload = {
       data: message,
-      meta: {
-        originating_service: originating_service || self.originating_service,
-      },
+      meta: meta,
     }
 
     producer_for(topic: on_topic) do |producer|

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.13.0'.freeze
+  VERSION = '0.13.1'.freeze
 end

--- a/spec/lib/fastly_nsq/messenger_spec.rb
+++ b/spec/lib/fastly_nsq/messenger_spec.rb
@@ -39,6 +39,32 @@ RSpec.describe FastlyNsq::Messenger do
 
       expect(producer).to have_received(:write).with(expected_attributes.to_json)
     end
+
+    it 'allows setting arbitrary metadata' do
+      meta = { test: 'test' }
+
+      expected_attributes = { data: message, meta: meta.merge(originating_service: origin) }
+
+      subject.producers['topic'] = producer
+
+      subject.deliver message: message, on_topic: 'topic', meta: meta, originating_service: origin
+
+      expect(producer).to have_received(:write).with(expected_attributes.to_json)
+    end
+
+    it 'prevents originating_service from being overwritten by meta' do
+      meta = { test: 'test' }
+
+      expected_attributes = { data: message, meta: meta.merge(originating_service: origin) }
+
+      meta[:originating_service] = 'other_service'
+
+      subject.producers['topic'] = producer
+
+      subject.deliver message: message, on_topic: 'topic', meta: meta, originating_service: origin
+
+      expect(producer).to have_received(:write).with(expected_attributes.to_json)
+    end
   end
 
   describe '#originating_service=' do


### PR DESCRIPTION

Reason for Change
===================
* Allow specifying custom metadata on a message.  We have a meta section on the message, but weren't allowing an accessible way to put data there.

List of Changes
===============
* Allows specifying custom metadata on a message.
* Update changelog and bump version

Risks
=====
* This is a backwards-compatible change.  The two possible risks here are:
  - you can override originating_service if you put that as part of the meta hash you pass
  - if you don't pass in a hash for meta, you'll get a runtime error.

These risks are negligible and will easily be discovered immediately as an operator error

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [X] I have NOT linked to any Jira tickets.
- [X] I have linked to all relevant reference issues or work requests
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added or updated necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing
