### PR TITLE
Don't log the logger object when creating a listener.

### DIFF
--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -27,7 +27,6 @@ module FastlyNsq
     def identity
       {
         consumer:     @consumer,
-        logger:       @logger,
         manager:      @manager,
         preprocessor: @preprocessor,
         processor:    @processor,

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,3 +1,3 @@
 module FastlyNsq
-  VERSION = '0.13.1'.freeze
+  VERSION = '0.13.2'.freeze
 end

--- a/spec/lib/fastly_nsq/listener_spec.rb
+++ b/spec/lib/fastly_nsq/listener_spec.rb
@@ -151,7 +151,6 @@ RSpec.describe FastlyNsq::Listener do
       it 'can describe itself' do
         id = listener.identity
         expect(id[:consumer]).to_not be_nil
-        expect(id[:logger]).to be logger
         expect(id[:manager]).to be manager
         expect(id[:preprocessor]).to be_nil
         expect(id[:processor]).to_not be_nil


### PR DESCRIPTION
Reason for Change
===================
* Because of an interesting interaction between the fluentd logger and is use of thread ID to log `last_error` logs were growing exponentially as new listener threads were created after errors were raised.

List of Changes
===============
Remove the `@logger` object from the `listener.identity` hash.


Recommended Reviewers
=====================
@fastly/billing