### PR TITLE
Retrieve meta section of message

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+### 0.13.2 / 2017-12-04
+
+* Reduce circular log output
+* Allow retrieving metadata similar to data.
+
 ### 0.13.1 / 2017-11-30
 
 * Allow specifying custom metadata on message delivery

--- a/lib/fastly_nsq/message.rb
+++ b/lib/fastly_nsq/message.rb
@@ -17,6 +17,10 @@ class FastlyNsq::Message
     @data ||= body['data']
   end
 
+  def meta
+    @meta ||= body['meta']
+  end
+
   def body
     @body ||= JSON.parse(raw_body)
   end

--- a/spec/lib/fastly_nsq/message_spec.rb
+++ b/spec/lib/fastly_nsq/message_spec.rb
@@ -3,7 +3,7 @@ require 'json'
 
 RSpec.describe FastlyNsq::Message do
   let(:nsq_message) { double 'Nsq::Message', body: json_body, attempts: nil, finish: nil, requeue: nil, touch: nil, timestamp: nil }
-  let(:body)        { { 'data' => 'goes here', 'other_field' => 'is over here' } }
+  let(:body)        { { 'data' => 'goes here', 'other_field' => 'is over here', 'meta' => 'meta stuff' } }
   let(:json_body)   { body.to_json }
   subject           { FastlyNsq::Message.new nsq_message }
 
@@ -17,6 +17,10 @@ RSpec.describe FastlyNsq::Message do
 
   it 'plucks data as data' do
     expect(subject.data).to eq('goes here')
+  end
+
+  it 'plucks meta as meta' do
+    expect(subject.meta).to eq(body['meta'])
   end
 
   it 'aliases raw_body to to_s' do


### PR DESCRIPTION
Reason for Change
===================
* Add a convenience method to retrieve the `meta` section of the message.

List of Changes
===============
* Add convenience method to retrieve `meta` section of message

Risks
=====
* Low risk change, retrieves meta from body if it exists, otherwise it returns nil.

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [X] I have NOT linked to any Jira tickets.
- [X] I have linked to all relevant reference issues or work requests
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added or updated necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/internal-engineering 
