### PR TITLE
fix: launcher heartbeat

### DIFF
--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -43,14 +43,14 @@ module FastlyNsq
 end
 
 require 'fastly_nsq/consumer'
-require 'fastly_nsq/priority_thread_pool'
-require 'fastly_nsq/priority_queue'
 require 'fastly_nsq/feeder'
 require 'fastly_nsq/launcher'
 require 'fastly_nsq/listener'
 require 'fastly_nsq/manager'
 require 'fastly_nsq/message'
 require 'fastly_nsq/messenger'
+require 'fastly_nsq/priority_queue'
+require 'fastly_nsq/priority_thread_pool'
 require 'fastly_nsq/producer'
 require 'fastly_nsq/tls_options'
 require 'fastly_nsq/version'

--- a/lib/fastly_nsq/cli.rb
+++ b/lib/fastly_nsq/cli.rb
@@ -25,19 +25,17 @@ class FastlyNsq::CLI
 
   def run
     startup
-    begin
-      # Multithreading begins here ----
-      launcher.run
 
-      read_loop
-    rescue Interrupt
-      FastlyNsq.logger.info 'Shutting down'
-      launcher.stop
-      # Explicitly exit so busy Processor threads can't block
-      # process shutdown.
-      FastlyNsq.logger.info 'Bye!'
-      exit(0)
-    end
+    launcher.beat
+
+    read_loop
+  rescue Interrupt
+    FastlyNsq.logger.info 'Shutting down'
+    launcher.stop
+    # Explicitly exit so busy Processor threads can't block
+    # process shutdown.
+    FastlyNsq.logger.info 'Bye!'
+    exit(0)
   end
 
   private


### PR DESCRIPTION
Reason for Change
===================
* Fix broken heartbeat log lines

List of Changes
===============
* Refactor the launcher for testing.  
* Heartbeat messages contains useful information about the pool

```
D, [2018-01-05T11:06:00.448682 #39195] DEBUG -- : HEARTBEAT: busy: 0 processed: 0 max_threads: 3 max_queue_size: 0 listeners: 1
```

Risks
=====
* None

Recommended Reviewers
=====================
@fastly/billing
  