### PR TITLE
upgrade nsq-ruby to ~> 2.2

### DIFF
--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock', '~> 3.0'
 
   gem.add_dependency 'concurrent-ruby', '~> 1.0'
-  gem.add_dependency 'nsq-ruby', '~> 2.0', '>= 2.0.5'
+  gem.add_dependency 'nsq-ruby', '~> 2.2'
   gem.add_dependency 'priority_queue_cxx', '~> 0.3'
 end

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FastlyNsq
-  VERSION = '1.0.2'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
Reason for Change
===================
* 2.2 includes a fix for memory leakage (https://github.com/wistia/nsq-ruby/pull/42)

A simple `bundle update nsq-ruby` would work in most cases but this will ensure the version w/o memory leaks is used in the future.

List of Changes
===============
* Update Gemspec

Risks
=====
* None.

Recommended Reviewers
=====================
@fastly/internal-engineering 