### PR TITLE
feature: allow specifications of consumer options via listener

### DIFF
--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock', '~> 3.0'
 
   gem.add_dependency 'concurrent-ruby', '~> 1.0'
-  gem.add_dependency 'nsq-ruby', '~> 2.2'
+  gem.add_dependency 'nsq-ruby', '~> 2.3'
   gem.add_dependency 'priority_queue_cxx', '~> 0.3'
 end

--- a/lib/fastly_nsq/consumer.rb
+++ b/lib/fastly_nsq/consumer.rb
@@ -9,13 +9,13 @@ class FastlyNsq::Consumer
 
   def_delegators :connection, :size, :terminate, :connected?, :pop, :pop_without_blocking
 
-  def initialize(topic:, channel:, queue: nil, tls_options: nil, connect_timeout: DEFAULT_CONNECTION_TIMEOUT)
+  def initialize(topic:, channel:, queue: nil, tls_options: nil, connect_timeout: DEFAULT_CONNECTION_TIMEOUT, **options)
     @topic           = topic
     @channel         = channel
     @tls_options     = FastlyNsq::TlsOptions.as_hash(tls_options)
     @connect_timeout = connect_timeout
 
-    @connection = connect(queue)
+    @connection = connect(queue, **options)
   end
 
   def empty?
@@ -26,13 +26,14 @@ class FastlyNsq::Consumer
 
   attr_reader :tls_options
 
-  def connect(queue)
+  def connect(queue, **options)
     Nsq::Consumer.new(
       {
         nsqlookupd: FastlyNsq.lookupd_http_addresses,
         topic: topic,
         channel: channel,
         queue: queue,
+        **options,
       }.merge(tls_options),
     )
   end

--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -11,7 +11,8 @@ class FastlyNsq::Listener
   attr_reader :preprocessor, :topic, :processor, :priority, :channel, :logger, :consumer
 
   def initialize(topic:, processor:, preprocessor: FastlyNsq.preprocessor, channel: FastlyNsq.channel, consumer: nil,
-                 logger: FastlyNsq.logger, priority: DEFAULT_PRIORITY, connect_timeout: DEFAULT_CONNECTION_TIMEOUT)
+                 logger: FastlyNsq.logger, priority: DEFAULT_PRIORITY, connect_timeout: DEFAULT_CONNECTION_TIMEOUT,
+                 **consumer_options)
 
     raise ArgumentError, "processor #{processor.inspect} does not respond to #call" unless processor.respond_to?(:call)
     raise ArgumentError, "priority #{priority.inspect} must be a Integer" unless priority.is_a?(Integer)
@@ -26,7 +27,8 @@ class FastlyNsq::Listener
     @consumer = consumer || FastlyNsq::Consumer.new(topic: topic,
                                                     connect_timeout: connect_timeout,
                                                     channel: channel,
-                                                    queue: FastlyNsq::Feeder.new(self, priority))
+                                                    queue: FastlyNsq::Feeder.new(self, priority),
+                                                    **consumer_options)
 
     FastlyNsq.manager.add_listener(self)
   end

--- a/spec/listener_spec.rb
+++ b/spec/listener_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe FastlyNsq::Listener do
   subject { described_class.new(topic: topic, channel: channel, processor: processor) }
 
   describe '#initialize' do
+    describe 'max_attempts' do
+      it 'can be passed to the consumer' do
+        listener = described_class.new topic: topic,
+                                       processor: processor,
+                                       channel: channel,
+                                       max_attempts: 5
+        expect { listener }.to eventually(be_connected).within(5)
+        nsq_connection = listener.consumer.connection.connections.values.first # whoa
+        expect(nsq_connection.instance_variable_get(:@max_attempts)).to eq(5)
+      end
+    end
+
     describe 'with FastlyNsq.channel set' do
       let!(:default_channel) { FastlyNsq.channel }
       before { FastlyNsq.channel = 'fnsq' }


### PR DESCRIPTION
__NOTE: Do NOT add any Jira links to this PR description or commits.  This is a public repository.__

Reason for Change
===================

Allows `max_attempts` to be set when initializing a listener

List of Changes
===============

* Expand method signatures of `FastlyNsq::Listener` and `FastlyNsq::Consumer` to allow options to be passed to the underlying connection object.

Risks
=====

None that I can see.

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing