### PR TITLE
global max_attempts setting

### DIFF
--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -14,6 +14,7 @@ module FastlyNsq
   class << self
     attr_accessor :channel
     attr_accessor :preprocessor
+    attr_accessor :max_attempts
     attr_writer :logger
 
     def listen(topic, processor, **options)

--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -12,7 +12,8 @@ module FastlyNsq
   ConnectionFailed = Class.new(StandardError)
 
   class << self
-    attr_accessor :channel, :preprocessor
+    attr_accessor :channel
+    attr_accessor :preprocessor
     attr_writer :logger
 
     def listen(topic, processor, **options)

--- a/lib/fastly_nsq/consumer.rb
+++ b/lib/fastly_nsq/consumer.rb
@@ -6,14 +6,16 @@ class FastlyNsq::Consumer
   DEFAULT_CONNECTION_TIMEOUT = 5 # seconds
 
   attr_reader :channel, :topic, :connection, :connect_timeout
+  attr_reader :max_attempts
 
   def_delegators :connection, :size, :terminate, :connected?, :pop, :pop_without_blocking
 
-  def initialize(topic:, channel:, queue: nil, tls_options: nil, connect_timeout: DEFAULT_CONNECTION_TIMEOUT, **options)
+  def initialize(topic:, channel:, queue: nil, tls_options: nil, connect_timeout: DEFAULT_CONNECTION_TIMEOUT, max_attempts: FastlyNsq.max_attempts, **options)
     @topic           = topic
     @channel         = channel
     @tls_options     = FastlyNsq::TlsOptions.as_hash(tls_options)
     @connect_timeout = connect_timeout
+    @max_attempts    = max_attempts
 
     @connection = connect(queue, **options)
   end
@@ -33,6 +35,7 @@ class FastlyNsq::Consumer
         topic: topic,
         channel: channel,
         queue: queue,
+        max_attempts: max_attempts,
         **options,
       }.merge(tls_options),
     )

--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -9,25 +9,28 @@ class FastlyNsq::Listener
   def_delegators :consumer, :connected?
 
   attr_reader :preprocessor, :topic, :processor, :priority, :channel, :logger, :consumer
+  attr_reader :max_attempts
 
   def initialize(topic:, processor:, preprocessor: FastlyNsq.preprocessor, channel: FastlyNsq.channel, consumer: nil,
                  logger: FastlyNsq.logger, priority: DEFAULT_PRIORITY, connect_timeout: DEFAULT_CONNECTION_TIMEOUT,
-                 **consumer_options)
+                 max_attempts: FastlyNsq.max_attempts, **consumer_options)
 
     raise ArgumentError, "processor #{processor.inspect} does not respond to #call" unless processor.respond_to?(:call)
     raise ArgumentError, "priority #{priority.inspect} must be a Integer" unless priority.is_a?(Integer)
 
     @channel      = channel
     @logger       = logger
+    @max_attempts = max_attempts
     @preprocessor = preprocessor
+    @priority     = priority
     @processor    = processor
     @topic        = topic
-    @priority     = priority
 
     @consumer = consumer || FastlyNsq::Consumer.new(topic: topic,
                                                     connect_timeout: connect_timeout,
                                                     channel: channel,
                                                     queue: FastlyNsq::Feeder.new(self, priority),
+                                                    max_attempts: max_attempts,
                                                     **consumer_options)
 
     FastlyNsq.manager.add_listener(self)

--- a/spec/listener_spec.rb
+++ b/spec/listener_spec.rb
@@ -15,15 +15,19 @@ RSpec.describe FastlyNsq::Listener do
   subject { described_class.new(topic: topic, channel: channel, processor: processor) }
 
   describe '#initialize' do
-    describe 'max_attempts' do
-      it 'can be passed to the consumer' do
-        listener = described_class.new topic: topic,
-                                       processor: processor,
-                                       channel: channel,
-                                       max_attempts: 5
+    describe 'with FastlyNsq.max_attempts set' do
+      let!(:default_max_attempts) { FastlyNsq.max_attempts }
+      before { FastlyNsq.max_attempts = 19 }
+      after { FastlyNsq.max_attempts = default_max_attempts }
+
+      it 'defaults to FastlyNsq.max_attempts' do
+        listener = described_class.new(topic: topic, processor: processor, channel: channel)
+        expect(listener.max_attempts).to eq(FastlyNsq.max_attempts)
+
         expect { listener }.to eventually(be_connected).within(5)
+
         nsq_connection = listener.consumer.connection.connections.values.first # whoa
-        expect(nsq_connection.instance_variable_get(:@max_attempts)).to eq(5)
+        expect(nsq_connection.instance_variable_get(:@max_attempts)).to eq(FastlyNsq.max_attempts)
       end
     end
 


### PR DESCRIPTION
Reason for Change
===================

`max_attempts`, like `logger` and `channel`, are extra useful with global defaults

List of Changes
===============

All `Consumer` and `Listener` `max_attempts` values will default to `FastlyNsq.max_attempts`

Risks
=====

None.

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing