### PR TITLE
standardize logging format and add attempts

### DIFF
--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -6,6 +6,7 @@ require 'fc'
 require 'set'
 require 'logger'
 require 'forwardable'
+require 'digest/md5'
 
 module FastlyNsq
   NotConnectedError = Class.new(StandardError)

--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -38,7 +38,7 @@ class FastlyNsq::Listener
 
   def call(nsq_message)
     message = FastlyNsq::Message.new(nsq_message)
-    logger.info "[NSQ] Message received on topic [#{topic}]: #{message}"
+    logger.info "topic #{topic}, attempts #{nsq_message.attempts} received: #{message}"
     preprocessor&.call(message)
     result = processor.call(message)
     message.finish if result
@@ -48,6 +48,6 @@ class FastlyNsq::Listener
   def terminate
     return unless connected?
     consumer.terminate
-    logger.info "< Consumer terminated: topic [#{topic}]"
+    logger.info "topic #{topic}, channel #{channel}: consumer terminated"
   end
 end

--- a/lib/fastly_nsq/manager.rb
+++ b/lib/fastly_nsq/manager.rb
@@ -43,10 +43,10 @@ class FastlyNsq::Manager
   end
 
   def add_listener(listener)
-    logger.info { "Listening to topic:'#{listener.topic}' on channel: '#{listener.channel}'" }
+    logger.info { "topic #{listener.topic}, channel #{listener.channel} listening" }
 
     if topic_listeners[listener.topic]
-      logger.warn { "topic: #{listener.topic} was added more than once" }
+      logger.warn { "topic #{listener.topic} was added more than once" }
     end
 
     topic_listeners[listener.topic] = listener

--- a/lib/fastly_nsq/manager.rb
+++ b/lib/fastly_nsq/manager.rb
@@ -43,10 +43,10 @@ class FastlyNsq::Manager
   end
 
   def add_listener(listener)
-    logger.info { "topic #{listener.topic}, channel #{listener.channel} listening" }
+    logger.info { "topic #{listener.topic}, channel #{listener.channel}: listening" }
 
     if topic_listeners[listener.topic]
-      logger.warn { "topic #{listener.topic} was added more than once" }
+      logger.warn { "topic #{listener.topic}: duplicate listener" }
     end
 
     topic_listeners[listener.topic] = listener

--- a/lib/fastly_nsq/testing.rb
+++ b/lib/fastly_nsq/testing.rb
@@ -62,9 +62,11 @@ module FastlyNsq
 
   class TestMessage
     attr_reader :raw_body
+    attr_reader :attempts
 
     def initialize(raw_body)
       @raw_body = raw_body
+      @attempts = 0
     end
 
     def body
@@ -78,7 +80,7 @@ module FastlyNsq
     end
 
     def requeue(*)
-      # sure
+      @attempts += 1
       true
     end
   end

--- a/lib/fastly_nsq/testing.rb
+++ b/lib/fastly_nsq/testing.rb
@@ -63,9 +63,11 @@ module FastlyNsq
   class TestMessage
     attr_reader :raw_body
     attr_reader :attempts
+    attr_reader :id
 
     def initialize(raw_body)
       @raw_body = raw_body
+      @id       = Digest::SHA1.hexdigest(raw_body.to_s + Time.now.to_s)
       @attempts = 0
     end
 

--- a/spec/listener_spec.rb
+++ b/spec/listener_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe FastlyNsq::Listener do
   end
 
   describe 'faking', :fake do
-    let!(:message) { { 'foo' => 'bar' } }
+    let!(:message) { JSON.dump('foo' => 'bar') }
 
     before { subject }
 
@@ -169,7 +169,7 @@ RSpec.describe FastlyNsq::Listener do
   end
 
   describe 'inline', :inline do
-    let!(:message) { { 'foo' => 'bar' } }
+    let!(:message) { JSON.dump('foo' => 'bar') }
     let!(:processor) { ->(m) { messages << m.raw_body } }
 
     before { subject }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ if ENV['DEBUG']
   FastlyNsq.logger = Logger.new(STDOUT)
 else
   Concurrent.use_stdlib_logger(Logger::ERROR)
-  FastlyNsq.logger = Logger.new(STDOUT).tap { |l| l.level = Logger::ERROR }
+  FastlyNsq.logger = Logger.new('/dev/null').tap { |l| l.level = Logger::DEBUG }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Reason for Change
===================

* Seeing `attempts` on message received is very useful information
* Standardizing logging format makes log parsing much easier

List of Changes
===============

* Add `attempts` to message received log line
* Use a similar format in log messages

Risks
=====

It's possible consumers with tight log integrations may break

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing