### PR TITLE
add exponential retries to FastlyNsq::Message

### DIFF
--- a/lib/fastly_nsq/message.rb
+++ b/lib/fastly_nsq/message.rb
@@ -34,10 +34,17 @@ class FastlyNsq::Message
     nsq_message.finish
   end
 
-  def requeue(*args)
+  def requeue(timeout = nil)
     return managed if managed
+    timeout ||= requeue_period
 
     @managed = :requeued
-    nsq_message.requeue(*args)
+    nsq_message.requeue(timeout)
+  end
+
+  private
+
+  def requeue_period
+    ((attempts**4) + 45 + (rand(60) * (attempts + 1))) * 1_000
   end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'json'
 
 RSpec.describe FastlyNsq::Message do
-  let(:nsq_message) { double 'Nsq::Message', body: json_body, attempts: nil, finish: nil, requeue: nil, touch: nil, timestamp: nil }
+  let(:nsq_message) { double 'Nsq::Message', body: json_body, attempts: 1, finish: nil, requeue: nil, touch: nil, timestamp: nil }
   let(:body)        { { 'data' => 'goes here', 'other_field' => 'is over here', 'meta' => 'meta stuff' } }
   let(:json_body)   { body.to_json }
   subject           { FastlyNsq::Message.new nsq_message }
@@ -56,5 +56,17 @@ RSpec.describe FastlyNsq::Message do
     subject.requeue
 
     expect(subject.managed).to eq(:finished)
+  end
+
+  it 'uses the passed timeout for the requeue timeout' do
+    expect(nsq_message).to receive(:requeue).with(1000)
+
+    subject.requeue(1000)
+  end
+
+  it 'uses exponential backoff for timeout if none is given' do
+    expect(nsq_message).to receive(:requeue).with(46_000..166_000)
+
+    subject.requeue
   end
 end


### PR DESCRIPTION
Reason for Change
===================
* We have several different places where we implement some message retry logic. Rather than adding exponential retries everywhere it makes sense to have it on the FastlyNsq::Message.

Risks
=====
* If max_attempts is not set you could end up with some VERY long requeue periods.

Checklist
=========
- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/internal-engineering 