### PR TITLE
Cap the requeue_period calculation at 30 attempts.

### DIFF
--- a/lib/fastly_nsq/message.rb
+++ b/lib/fastly_nsq/message.rb
@@ -45,6 +45,7 @@ class FastlyNsq::Message
   private
 
   def requeue_period
-    ((attempts**4) + 45 + (rand(60) * (attempts + 1))) * 1_000
+    retry_count = [attempts, 30].min
+    ((retry_count**4) + 45 + (rand(60) * (retry_count + 1))) * 1_000
   end
 end


### PR DESCRIPTION

Reason for Change
===================
* @alieander is smart and suggested we add a maximum so that we aren't requeueing messages with a timeout of many years.

List of Changes
===============
use `[attempts, 30].min` to calculate the requeue period. This limits requeue_period to a maximum of ~9.4 days.

Risks
=====
* None.

Checklist
=========
- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/internal-engineering 