### PR TITLE
add FastlyNsq::Testing.message

### DIFF
--- a/lib/fastly_nsq/testing.rb
+++ b/lib/fastly_nsq/testing.rb
@@ -51,6 +51,11 @@ module FastlyNsq
         return unless enabled?
         FastlyNsq::Messages.messages.clear
       end
+
+      def message(data:, meta: nil)
+        test_message = FastlyNsq::TestMessage.new(JSON.dump('data' => data, 'meta' => meta))
+        FastlyNsq::Message.new(test_message)
+      end
     end
   end
 

--- a/spec/testing_spec.rb
+++ b/spec/testing_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FastlyNsq::Testing do
+  describe '.message' do
+    it 'returns a FastlyNsq::Message' do
+      data = { 'foo' => 'bar' }
+      message = FastlyNsq::Testing.message(data: data)
+
+      expect(message.body).to eq('data' => data, 'meta' => nil)
+    end
+
+    it 'returns a FastlyNsq::Message with meta' do
+      data = { 'foo' => 'bar' }
+      meta = 'foo'
+      message = FastlyNsq::Testing.message(data: data, meta: meta)
+
+      expect(message.body).to eq('data' => data, 'meta' => meta)
+    end
+
+    it 'wraps a FastlyNsq::TestMessage' do
+      data = 'bar'
+      message = FastlyNsq::Testing.message(data: data)
+      expect(message.nsq_message).to be_a(FastlyNsq::TestMessage)
+      expect(message.nsq_message.body).to eq(JSON.dump('data' => data, 'meta' => nil))
+    end
+  end
+end


### PR DESCRIPTION
Reason for Change
===================

It is necessary to construct an object to meet the interface for `FastlyNsq::Listener#call(*)`.  We have many references like:

```ruby
let(:klass) { Struct.new(:data, :meta, :finish, :requeue) }

it { Listener.process(klass.new(*)) }
```

that superficially meets the interface required.  This removes the need for the con-Struct-tion (*jokes*) and creates a more accurate message object.


List of Changes
===============

* Add `FastlyNsq::Testing.message` to aid in testing

Risks
=====

None.

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing