### PR TITLE
Add `sent_at` to `meta` when `deliver` is called.

### DIFF
--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry-byebug', '~> 3.3'
   gem.add_development_dependency 'rspec', '~> 3.4'
   gem.add_development_dependency 'rspec-eventually', '0.2'
+  gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'webmock', '~> 3.0'
 
   gem.add_dependency 'concurrent-ruby', '~> 1.0'

--- a/lib/fastly_nsq/messenger.rb
+++ b/lib/fastly_nsq/messenger.rb
@@ -8,6 +8,7 @@ module FastlyNsq::Messenger
 
   def deliver(message:, topic:, originating_service: nil, meta: {})
     meta[:originating_service] = originating_service || self.originating_service
+    meta[:sent_at] = Time.now.iso8601(5)
 
     payload = {
       data: message,

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FastlyNsq
-  VERSION = '1.6.0'
+  VERSION = '1.7.0'
 end


### PR DESCRIPTION
Reason for Change
===================

With append-only data; timestamps are critical to be accurate and granular.  Because we can't guarantee that every sender of data onto NSQ is going to have all their timestamps be granular before being converted to JSON (which can lose granularity), we ensure a timestamp that at least tells us when this was trying to be delivered with granularity up to the 100,000th.

List of Changes
===============
* Add `sent_at` to `meta` in `deliver`
* Add Timecop for testing.

Risks
=====
* This basically prevents a `sent_at` from being added to the meta section of a message by a sender.

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [X] I have NOT linked to any Jira tickets.
- [X] I have linked to all relevant reference issues or work requests
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added or updated necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing
