### PR TITLE
add lifecyle callbacks

### DIFF
--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -12,11 +12,17 @@ module FastlyNsq
   NotConnectedError = Class.new(StandardError)
   ConnectionFailed = Class.new(StandardError)
 
+  LIFECYCLE_EVENTS = %i[startup shutdown heartbeat].freeze
+
   class << self
     attr_accessor :channel
     attr_accessor :preprocessor
     attr_accessor :max_attempts
     attr_writer :logger
+
+    def events
+      @events ||= LIFECYCLE_EVENTS.each_with_object({}) { |e, a| a[e] = [] }
+    end
 
     def listen(topic, processor, **options)
       FastlyNsq::Listener.new(topic: topic, processor: processor, **options)
@@ -41,6 +47,31 @@ module FastlyNsq
 
     def lookupd_http_addresses
       ENV.fetch('NSQLOOKUPD_HTTP_ADDRESS').split(',').map(&:strip)
+    end
+
+    # Register a block to run at a point in the lifecycle.
+    # :startup, :heartbeat or :shutdown are valid events.
+    #
+    #   FastlyNsq.configure do |config|
+    #     config.on(:shutdown) do
+    #       puts "Goodbye cruel world!"
+    #     end
+    #   end
+    def on(event, &block)
+      event = event.to_sym
+      raise ArgumentError, "Invalid event name: #{event}" unless LIFECYCLE_EVENTS.include?(event)
+      events[event] << block
+    end
+
+    def fire_event(event)
+      blocks = FastlyNsq.events.fetch(event)
+      blocks.each do |block|
+        begin
+          block.call
+        rescue => e
+          logger.error "[#{event}] #{e.inspect}"
+        end
+      end
     end
   end
 end

--- a/lib/fastly_nsq/launcher.rb
+++ b/lib/fastly_nsq/launcher.rb
@@ -19,6 +19,7 @@ class FastlyNsq::Launcher
     @logger  = logger
 
     FastlyNsq.manager = FastlyNsq::Manager.new(options)
+    FastlyNsq.fire_event :startup
   end
 
   def beat
@@ -28,6 +29,7 @@ class FastlyNsq::Launcher
   def stop
     @done = true
     manager.terminate(timeout)
+    FastlyNsq.fire_event :shutdown
   end
 
   def stop_listeners
@@ -57,6 +59,8 @@ class FastlyNsq::Launcher
     #       ::Process.kill('dieing because...', $$)
   rescue => e
     logger.error "Heartbeat error: #{e.message}"
+  ensure
+    FastlyNsq.fire_event :heartbeat
   end
 
   def start_heartbeat

--- a/spec/fastly_nsq_spec.rb
+++ b/spec/fastly_nsq_spec.rb
@@ -69,4 +69,20 @@ RSpec.describe FastlyNsq do
       expect(subject.lookupd_http_addresses).to eq(ENV['NSQLOOKUPD_HTTP_ADDRESS'].split(','))
     end
   end
+
+  describe '#on' do
+    before { FastlyNsq.events.each { |(_, v)| v.clear } }
+    after  { FastlyNsq.events.each { |(_, v)| v.clear } }
+
+    it 'registers callbacks for events' do
+      %i[startup shutdown heartbeat].each do |event|
+        block = -> {}
+        expect { FastlyNsq.on(event, &block) }.to change { FastlyNsq.events[event] }.by([block])
+      end
+    end
+
+    it 'limits callback registration to valid events' do
+      expect { FastlyNsq.on(:foo, &-> {}) }.to raise_error(ArgumentError, /Invalid event name/)
+    end
+  end
 end

--- a/spec/launcher_spec.rb
+++ b/spec/launcher_spec.rb
@@ -3,19 +3,21 @@
 require 'spec_helper'
 
 RSpec.describe FastlyNsq::Launcher do
-  let!(:options)  { { max_threads: 3, timeout: 9 } }
-  let!(:launcher) { FastlyNsq::Launcher.new options }
-  let!(:topic)    { 'fnsq' }
   let!(:channel)  { 'fnsq' }
+  let!(:options)  { { max_threads: 3, timeout: 9 } }
+  let!(:topic)    { 'fnsq' }
+
+  let(:launcher) { FastlyNsq::Launcher.new options }
   let(:listener)  { FastlyNsq::Listener.new(topic: topic, channel: channel, processor: ->(*) {}) }
+  let(:manager) { launcher.manager }
 
   before { reset_topic(topic, channel: channel) }
   before { expect { listener }.to eventually(be_connected).within(5) }
   after  { listener.terminate if listener.connected? }
 
-  let(:manager) { launcher.manager }
-
   it 'creates a manager with correct options' do
+    launcher
+
     expect(FastlyNsq.manager.pool.max_threads).to eq(3)
   end
 
@@ -30,6 +32,8 @@ RSpec.describe FastlyNsq::Launcher do
   end
 
   describe '#stop_listeners' do
+    before { launcher }
+
     it 'stops listeners and sets done' do
       expect(launcher).not_to be_stopping
       expect(manager).to receive(:stop_listeners)
@@ -42,9 +46,45 @@ RSpec.describe FastlyNsq::Launcher do
   end
 
   describe '#stop' do
+    before { launcher }
+
     it 'stops the manager within a deadline' do
       expect(manager).to receive(:terminate).with(options[:timeout])
       launcher.stop
+    end
+  end
+
+  describe 'callbacks' do
+    before { FastlyNsq.events.each { |(_, v)| v.clear } }
+    after  { FastlyNsq.events.each { |(_, v)| v.clear } }
+
+    it 'fires :startup event on initialization' do
+      obj = spy
+      block = -> { obj.start }
+      FastlyNsq.on(:startup, &block)
+
+      launcher
+      expect(obj).to have_received(:start)
+    end
+
+    it 'fires :shutdown event on #stop' do
+      launcher
+
+      obj = spy
+      block = -> { obj.stop }
+      FastlyNsq.on(:shutdown, &block)
+
+      launcher.stop
+      expect(obj).to have_received(:stop)
+    end
+
+    it 'fires :heartbeat event on #heartbeat' do
+      obj = spy
+      block = -> { obj.beat }
+      FastlyNsq.on(:heartbeat, &block)
+      launcher.beat
+
+      expect { obj }.to eventually(have_received(:beat).at_least(:once)).within(0.5)
     end
   end
 end


### PR DESCRIPTION
Reason for Change
===================

Support instrumentation such as Prometheus.

List of Changes
===============

* Add callbacks at key events in the process lifecycle to support instrumentation.

Risks
=====

These events do nothing if callbacks are not registered so the only risk is bugs.

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing