### PR TITLE
Remove README line about point release...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # fastly_nsq [![Build Status](https://travis-ci.org/fastly/fastly_nsq.svg?branch=master)](https://travis-ci.org/fastly/fastly_nsq)
 
-*NOTE: This is a point-release
-which is not yet suitable for production.
-Use at your own peril.*
-
 NSQ adapter and testing objects
 for using the NSQ messaging system
 in your Ruby project.


### PR DESCRIPTION
Reason for Change
===================

`fastly_nsq` release 1.0 some time ago. Lets remove the point release
peril statement.

Fastly is using this in production but you still use at your own peril :P