### PR TITLE
Support writing multiple messages in FastlyNsq::Messenger

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ You can also set the originating service for all `deliver` calls:
 FastlyNsq::Messenger.originating_service = 'some awesome service'
 ```
 
+`FastlyNsq::Messenger` also spuports delivering multiple message at once and will
+use the NSQ `mpub` directive under the hood.
+
+```ruby
+FastlyNsq::Messenger.deliver_multi(messages: array_of_msgs, topic: 'my_topic')
+```
+
 `FastlyNsq::Messenger` can also be used to manage Producer connections
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -291,6 +291,19 @@ NSQLOOKUPD_HTTP_ADDRESS='127.0.0.1:4161, 10.1.1.101:4161'
 See the [`.sample.env`](examples/.sample.env) file
 for more detail.
 
+## Development
+
+The fastest way to get up and running for development is to use
+the Docker container provided by Docker Compose:
+
+* Clone: `git clone https://github.com/fastly/fastly_nsq.git`
+* `cd fastly_nsq`
+* run `bundle install`
+* run `docker-compose up -d`
+* `rake spec`
+
+You will still need the `ENV` variables as defined above.
+
 ## Contributors
 
 * Adarsh Pandit ([@adarsh](https://github.com/adarsh))

--- a/lib/fastly_nsq/consumer.rb
+++ b/lib/fastly_nsq/consumer.rb
@@ -55,7 +55,7 @@ class FastlyNsq::Consumer
   # @!method terminate
   #   Delegated to +self.connection+
   #   @return [Nsq::Consumer#terminate]
-  #   @see https://www.rubydoc.info/gems/nsq-ruby/Nsq%2FConsumer:terminate Nsq::Consumer#terminate
+  #   @see https://www.rubydoc.info/gems/nsq-ruby/Nsq%2FClientBase:terminate Nsq::ClientBase#terminate
   def_delegators :connection, :connected?, :pop, :pop_without_blocking, :size, :terminate
 
   ##

--- a/lib/fastly_nsq/messenger.rb
+++ b/lib/fastly_nsq/messenger.rb
@@ -36,6 +36,34 @@ module FastlyNsq::Messenger
     deliver_payload(topic: topic, payload: payload.to_json)
   end
 
+  ##
+  # Deliver many NSQ messages at once. Uses +mpub+
+  # @param messages [Array] Array of message which will be written to +data+ key of the
+  #   individual NSQ message payload. Each message needs to respond to +to_json(*)+.
+  # @param topic [String] NSQ topic on which to deliver the message
+  # @param originating_service [String] added to meta key of message payload
+  # @param meta [Hash]
+  # @return [Void]
+  # @example
+  #   FastlyNsq::Messenger.deliver_multi(
+  #     messages: [{a: 1, count: 11}, {a: 2, count: 22}],
+  #     topic: 'counts',
+  #   )
+  def deliver_multi(messages:, topic:, originating_service: nil, meta: {})
+    meta = populate_meta(originating_service: originating_service, meta: meta)
+
+    payload = messages.each_with_object([]) do |message, a|
+      msg = {
+        data: message,
+        meta: meta,
+      }
+
+      a << msg.to_json
+    end
+
+    deliver_payload(topic: topic, payload: payload)
+  end
+
   def originating_service=(service)
     @originating_service = service
   end

--- a/lib/fastly_nsq/messenger.rb
+++ b/lib/fastly_nsq/messenger.rb
@@ -17,6 +17,10 @@ module FastlyNsq::Messenger
 
   ##
   # Deliver an NSQ message. Uses +pub+
+  #
+  # Will add two keys to the `+meta+ payload that cannot be overidden:
+  #   +originating_service+ which defaults to {FastlyNsq#originating_service} and
+  #   +sent_at+ which will be set to +Time.now.iso8601(5)+ when the payload is created.
   # @param message [#to_json(*)] written to the +data+ key of the NSQ message payload
   # @param topic [String] NSQ topic on which to deliver the message
   # @param originating_service [String] added to meta key of message payload
@@ -38,6 +42,12 @@ module FastlyNsq::Messenger
 
   ##
   # Deliver many NSQ messages at once. Uses +mpub+
+  #
+  # For each message will add two keys to the `+meta+ payload of each message
+  # that cannot be overidden:
+  #   +originating_service+ which defaults to {FastlyNsq#originating_service} and
+  #   +sent_at+ which will be set to +Time.now.iso8601(5)+ when messages are processed.
+  #   The +sent_at+ time and +originating_service+ will be the same for every message.
   # @param messages [Array] Array of message which will be written to +data+ key of the
   #   individual NSQ message payload. Each message needs to respond to +to_json(*)+.
   # @param topic [String] NSQ topic on which to deliver the message

--- a/lib/fastly_nsq/messenger.rb
+++ b/lib/fastly_nsq/messenger.rb
@@ -16,12 +16,17 @@ module FastlyNsq::Messenger
   module_function
 
   ##
-  # Deliver an NSQ message
-  # @param message [#to_s] written to the +data+ key of the NSQ message payload
+  # Deliver an NSQ message. Uses +pub+
+  # @param message [#to_json(*)] written to the +data+ key of the NSQ message payload
   # @param topic [String] NSQ topic on which to deliver the message
   # @param originating_service [String] added to meta key of message payload
   # @param meta [Hash]
   # @return [Void]
+  # @example
+  #   FastlyNsq::Messenger.deliver(
+  #     message: {a: 1, count: 123},
+  #     topic: 'count',
+  #   )
   def deliver(message:, topic:, originating_service: nil, meta: {})
     payload = {
       data: message,

--- a/lib/fastly_nsq/producer.rb
+++ b/lib/fastly_nsq/producer.rb
@@ -27,7 +27,7 @@ class FastlyNsq::Producer
 
   def write(message)
     raise FastlyNsq::NotConnectedError unless connected?
-    connection.write message
+    connection.write(*message)
   end
 
   def connect

--- a/lib/fastly_nsq/producer.rb
+++ b/lib/fastly_nsq/producer.rb
@@ -1,10 +1,35 @@
 # frozen_string_literal: true
 
+# Provides an adapter to an Nsq::Producer
+# and used to write messages to the queue.
+#
+# @example
+#   producer = FastlyNsq::Producer.new(topic: 'topic)
+#   producer.write('my message')
 class FastlyNsq::Producer
   DEFAULT_CONNECTION_TIMEOUT = 5 # seconds
 
-  attr_reader :topic, :connect_timeout, :connection, :logger
+  # @return [String] NSQ Topic
+  attr_reader :topic
 
+  # @return [Nsq::Producer]
+  attr_reader :connection
+
+  # @return [Integer] connection timeout in seconds
+  attr_reader :connect_timeout
+
+  # @return [Logger]
+  attr_reader :logger
+
+  ##
+  # Create a FastlyNsq::Producer
+  #
+  # @param topic [String] NSQ topic on which to deliver the message
+  # @param tls_options [Hash] Hash of TSL options passed the connection.
+  #   In most cases this should be nil unless you need to override the
+  #   default values set in ENV.
+  # @param logger [Logger] defaults to FastlyNsq.logger
+  # @param connect_timeout [Integer] NSQ connection timeout in seconds
   def initialize(topic:, tls_options: nil, logger: FastlyNsq.logger, connect_timeout: DEFAULT_CONNECTION_TIMEOUT)
     @topic           = topic
     @tls_options     = FastlyNsq::TlsOptions.as_hash(tls_options)
@@ -14,22 +39,37 @@ class FastlyNsq::Producer
     connect
   end
 
+  ##
+  # Terminate the NSQ connection and set connection instance to +nil+
+  # @return [Nsq::Producer#terminate]
+  # @see https://www.rubydoc.info/gems/nsq-ruby/Nsq%2FClientBase:terminate Nsq::ClientBase#terminate
   def terminate
     connection.terminate
     @connection = nil
   end
 
+  ##
+  # Check conenction status
+  # @return [Nsq::Consumer#connected?]
+  # @see https://www.rubydoc.info/gems/nsq-ruby/Nsq/ClientBase#connected%3F-instance_method Nsq::ClientBase#connected?
   def connected?
     return false unless connection
 
     connection.connected?
   end
 
+  ##
+  # Write a message
+  # @return [Nsq::Producer#pop]
+  # @see https://www.rubydoc.info/gems/nsq-ruby/Nsq%2FProducer:write Nsq::Producer#write
   def write(message)
     raise FastlyNsq::NotConnectedError unless connected?
     connection.write(*message)
   end
 
+  ##
+  # Create an Nsq::Producer and set as +@connection+ instance variable
+  # @return [Boolean]
   def connect
     lookupd = FastlyNsq.lookupd_http_addresses
 

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe FastlyNsq::Producer do
     expect { message_count(topic) }.to eventually(eq(1)).within(5)
   end
 
+  it 'writes multiple messages' do
+    subject.write %w[foo bar]
+    expect { message_count(topic) }.to eventually(eq(2)).within(5)
+  end
+
   it 'should terminate' do
     expect { subject.terminate }.to change(subject, :connected?).to(false)
     expect(subject.connection).to eq(nil)


### PR DESCRIPTION
Reason for Change
===================
`Nsq::Producer` supports writing messages using `mpub` when multiple arguments are passed to `write`.  

This update adds support to multiple messages in `Fastly::Messenger` using `.deliver_multi`

List of Changes
===============
* add new method `Fastly::Messenger.deliver_multi` that takes an array of messages
* update `Nsq::Producer` to splat the arg list that is sent to `write` so that we can support passing in an array.
* Documentation updates.

Risks
=====
* Low. This is a new method and the implementation of `deliver` did not change.

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing