### PR TITLE
require pry only if pry is available already

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,10 @@
 # Change Log
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) as of [Version 1.9.1](#v1.9.1)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Removed
+- Removed `pry` as an undocumented requirement for `bin/fastly_nsq`
 
 ## [v1.9.0](https://github.com/fastly/fastly_nsq/tree/v1.9.0) (2018-06-04)
 [Full Changelog](https://github.com/fastly/fastly_nsq/compare/v1.8.0...v1.9.0)

--- a/bin/fastly_nsq
+++ b/bin/fastly_nsq
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'pry'
 require 'fastly_nsq/cli'
 
 begin

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FastlyNsq
-  VERSION = '1.9.0'
+  VERSION = '1.9.1'
 end


### PR DESCRIPTION
We do not need this for the CLI at all... its just a nice to have.
We are also not declaring this as a dependancy so we can not just assume
that it will exist.

Reason for Change
===================
requiring pry when it is not around causes crashes...
We are not going to add pry as a dep.

List of Changes
===============
Wrap `require 'pry'` in a being; rescue LoadError; end

Risks
=====
none.

Checklist
=========
- [x] Any dependent changes have been merged and published in downstream

Recommended Reviewers
=====================
@fastly/billing