### PR TITLE
implement pop and pop_without_blocking for test mode

### DIFF
--- a/lib/fastly_nsq/testing.rb
+++ b/lib/fastly_nsq/testing.rb
@@ -275,6 +275,14 @@ module FastlyNsq
       FastlyNsq::Testing.enabled? ? messages.empty? : super
     end
 
+    def pop
+      FastlyNsq::Testing.enabled? ? messages(topic)&.pop : super
+    end
+
+    def pop_without_blocking
+      FastlyNsq::Testing.enabled? ? messages(topic)&.pop : super
+    end
+
     def size
       FastlyNsq::Testing.enabled? ? messages.size : super
     end


### PR DESCRIPTION
Reason for Change
===================
This addition allows testing direct usage of `consumer.pop` or `consumer.pop_wihtout_blocking` 

Risks
=====
* None. test-mode only changes.

Recommended Reviewers
=====================
@fastly/internal-engineering 