### PR TITLE
add max_req_timeout [IE-2040]

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ FastlyNsq.configure do |config|
   config.logger = Logger.new
   config.preprocessor = ->(_) { FastlyNsq.logger.info 'PREPROCESSESES' }
 
+  config.max_attempts = 20
+  config.max_req_timeout = (60 * 60 * 4 * 1_000) # 4 hours
+
   lc.listen 'posts', ->(m) { puts "posts: #{m.body}" }
   lc.listen 'blogs', ->(m) { puts "blogs: #{m.body}" }, priority: 3
 end

--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -26,6 +26,10 @@ module FastlyNsq
     # @return [Integer]
     attr_accessor :max_attempts
 
+    # Set Maximum requeue timeout in milliseconds
+    # @return [Integer]
+    attr_writer :max_req_timeout
+
     # @return [Logger]
     attr_writer :logger
 
@@ -85,6 +89,17 @@ module FastlyNsq
     def manager=(manager)
       @manager&.transfer(manager)
       @manager = manager
+    end
+
+    ##
+    # Maximum requeue timeout in milliseconds. This setting controls the
+    # maximum value that will be sent from FastlyNsq::Message#requeue This
+    # value should be less than or equal to the nsqd command line option
+    # +max-req-timeout+. The default setting is 1 hour.
+    # @return [Integer]
+    # @see https://nsq.io/components/nsqd.html#command-line-options
+    def max_req_timeout
+      @max_req_timeout ||= ENV.fetch('MAX_REQ_TIMEOUT', 60 * 60 * 1_000)
     end
 
     ##

--- a/lib/fastly_nsq/message.rb
+++ b/lib/fastly_nsq/message.rb
@@ -64,10 +64,15 @@ class FastlyNsq::Message
 
   ##
   # Requeue an NSQ Message
+  # If the +timeout+ parameter or the caclulated backoff is greater
+  # than FastlyNsq.max_req_timeout, the +max_req_timeout+ will be used
+  # to requeue the message.
   # @param timeout [Integer] timeout in milliseconds
   def requeue(timeout = nil)
     return managed if managed
     timeout ||= requeue_period
+
+    timeout = [timeout, FastlyNsq.max_req_timeout].min
 
     @managed = :requeued
     nsq_message.requeue(timeout)

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -69,4 +69,10 @@ RSpec.describe FastlyNsq::Message do
 
     subject.requeue
   end
+
+  it 'uses the FastlyNsq.max_req_timeout it timeout is larger than FastlyNsq.max_req_timeout' do
+    expect(nsq_message).to receive(:requeue).with(60 * 60 * 1_000)
+
+    subject.requeue(60 * 60 * 4 * 1_000)
+  end
 end


### PR DESCRIPTION
Reason for Change
===================

Helps ensure we don't requeue messages
with a timeout larger than the nsqd conifgured max_timeout which will
result in an error like

```
E_INVALID REQ timeout 6836000000000 out of range 0-3600000000000
```

This setting can be configured via the `attr_writer` or via an ENV variable. It defaults to 1 hour.

List of Changes
===============
* add attr_writer for `max_req_timeout` and reader method that memoizes the default.
* update the `FastlyNsq::Message#requeue` to support `max_req_timeout` and only send the a timeout value less than or equal to the max.

Risks
=====
* Low. 

Checklist
=========
- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/internal-engineering 