### PR TITLE
Ensure max_req_timeout is integer when fetching from ENV

### DIFF
--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -99,7 +99,7 @@ module FastlyNsq
     # @return [Integer]
     # @see https://nsq.io/components/nsqd.html#command-line-options
     def max_req_timeout
-      @max_req_timeout ||= ENV.fetch('MAX_REQ_TIMEOUT', 60 * 60 * 1_000)
+      @max_req_timeout ||= ENV.fetch('MAX_REQ_TIMEOUT', 60 * 60 * 1_000).to_i
     end
 
     ##

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FastlyNsq
-  VERSION = '1.10.0'
+  VERSION = '1.10.1'
 end


### PR DESCRIPTION
Reason for Change
===================
`max_req_timeout` needs to be an integer.

Risks
=====
None.

Recommended Reviewers
=====================
@fastly/billing
