### PR TITLE
Updates for  STDERR and STDOUT redirection when daemonizing.

### DIFF
--- a/lib/fastly_nsq/cli.rb
+++ b/lib/fastly_nsq/cli.rb
@@ -223,11 +223,13 @@ class FastlyNsq::CLI
 
     reopen(files_to_reopen)
 
-    [$stdout, $stderr].each do |io|
-      File.open(options.fetch(:logfile, '/dev/null'), 'ab') do |f|
-        io.reopen(f)
+    if options[:logfile]
+      [$stdout, $stderr].each do |io|
+        File.open(options.fetch(:logfile, '/dev/null'), 'ab') do |f|
+          io.reopen(f)
+        end
+        io.sync = true
       end
-      io.sync = true
     end
     $stdin.reopen('/dev/null')
 

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FastlyNsq
-  VERSION = '1.10.1'
+  VERSION = '1.11.0'
 end


### PR DESCRIPTION
Reason for Change
===================
When running the CLI under a process manager like `sv` we don't pass a log file which means STDERR and STDOUT to `/dev/null` which makes tracking errors impossible.

List of Changes
===============
Only do redirection if a log file is passed.

Recommended Reviewers
=====================
@fastly/billing