### PR TITLE
Revert "Updates for  STDERR and STDOUT redirection when daemonizing."

### DIFF
--- a/lib/fastly_nsq/cli.rb
+++ b/lib/fastly_nsq/cli.rb
@@ -223,13 +223,11 @@ class FastlyNsq::CLI
 
     reopen(files_to_reopen)
 
-    if options[:logfile]
-      [$stdout, $stderr].each do |io|
-        File.open(options.fetch(:logfile, '/dev/null'), 'ab') do |f|
-          io.reopen(f)
-        end
-        io.sync = true
+    [$stdout, $stderr].each do |io|
+      File.open(options.fetch(:logfile, '/dev/null'), 'ab') do |f|
+        io.reopen(f)
       end
+      io.sync = true
     end
     $stdin.reopen('/dev/null')
 

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FastlyNsq
-  VERSION = '1.11.0'
+  VERSION = '1.10.1'
 end


### PR DESCRIPTION
Reverts fastly/fastly_nsq#87

This is only when using the `daemonize` option so the changes in #87 don't make any sense.

Will bump the version and release after merge