### PR TITLE
Add exception handling and logging for listeners

### DIFF
--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FastlyNsq
-  VERSION = '1.10.1'
+  VERSION = '1.12.0'
 end


### PR DESCRIPTION
Reason for Change
===================

The ThreadPoolExecutor will swallow exceptions:

https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent/executor/ruby_thread_pool_executor.rb#L347-L352

And because we don't set up a logger in `Concurrent` even the `log DEBUG` is silent because the default logger level is `fatal`. 

Rather then mess with the concurrent logger or leave this PR adds basic exception handling and logging to the block that is added to the executor.

Risks
=====
* Low

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing