### PR TITLE
set Nsq.logger when setting logger

### DIFF
--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -30,9 +30,6 @@ module FastlyNsq
     # @return [Integer]
     attr_writer :max_req_timeout
 
-    # @return [Logger]
-    attr_writer :logger
-
     ##
     # Map of lifecycle events
     # @return [Hash]
@@ -51,8 +48,18 @@ module FastlyNsq
       FastlyNsq::Listener.new(topic: topic, processor: processor, **options)
     end
 
+    ##
+    # @return [Logger]
     def logger
       @logger ||= Logger.new(nil)
+    end
+
+    ##
+    # Set the logger and also set Nsq.logger
+    # @params logger [Logger]
+    def logger=(new_logger)
+      Nsq.logger = new_logger
+      @logger = new_logger
     end
 
     ##

--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -49,9 +49,12 @@ module FastlyNsq
     end
 
     ##
+    # Return logger or set logger to default.
     # @return [Logger]
     def logger
-      @logger ||= Logger.new(nil)
+      return @logger if @logger
+
+      self.logger = Logger.new(STDERR)
     end
 
     ##

--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -58,8 +58,7 @@ module FastlyNsq
     # Set the logger and also set Nsq.logger
     # @params logger [Logger]
     def logger=(new_logger)
-      Nsq.logger = new_logger
-      @logger = new_logger
+      @logger = Nsq.logger = new_logger
     end
 
     ##

--- a/spec/fastly_nsq_spec.rb
+++ b/spec/fastly_nsq_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe FastlyNsq do
 
       expect(subject.logger).to eq logger
     end
+
+    it 'sets Nsq.logger' do
+      logger = Logger.new(STDOUT)
+      subject.logger = logger
+
+      expect(Nsq.logger).to eq logger
+    end
   end
 
   describe '#manager' do

--- a/spec/fastly_nsq_spec.rb
+++ b/spec/fastly_nsq_spec.rb
@@ -35,6 +35,28 @@ RSpec.describe FastlyNsq do
     end
   end
 
+  describe '#logger' do
+    let!(:default_logger) { subject.logger }
+    after { subject.logger = default_logger }
+
+    it 'returns the set logger' do
+      logger = Logger.new(nil)
+      subject.logger = logger
+
+      expect(subject.logger).to eq logger
+    end
+
+    it 'sets the default logger if none is set' do
+      subject.instance_variable_set(:@logger, nil)
+      expect(subject.instance_variable_get(:@logger)).to be nil
+      logger = subject.logger
+
+      expect(logger).to be_instance_of(Logger)
+      expect(logger.instance_variable_get(:@logdev).dev).to eq(STDERR)
+      expect(logger).to eq(Nsq.logger)
+    end
+  end
+
   describe '#logger=' do
     let!(:default_logger) { subject.logger }
     after { subject.logger = default_logger }

--- a/spec/fastly_nsq_spec.rb
+++ b/spec/fastly_nsq_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe FastlyNsq do
     it 'registers callbacks for events' do
       %i[startup shutdown heartbeat].each do |event|
         block = -> {}
-        expect { FastlyNsq.on(event, &block) }.to change { FastlyNsq.events[event] }.by([block])
+        FastlyNsq.on(event, &block)
+        expect(FastlyNsq.events[event]).to eq([block])
       end
     end
 


### PR DESCRIPTION
Reason for Change
===================
If we don't set `Nsq.logger` it's logs to /dev/null
https://github.com/wistia/nsq-ruby/blob/8774b0a8a06389f3664e86d1d5263807a51aca9d/lib/nsq/logger.rb#L3

Also set the default logger to `Logger.new(STDERR)` 

Risks
=====
* Low. adds logging setup to Nsq.logger so we have visibility there

Checklist
=========
_Put an `x` in the boxes that apply. 
You can also fill these out after creating the PR._

- [x] I have NOT linked to any Jira tickets.
- [x] I have linked to all relevant reference issues or work requests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream


Recommended Reviewers
=====================
@fastly/billing