### PR TITLE
Consumer still attempts connections in Test mode

### DIFF
--- a/lib/fastly_nsq/testing.rb
+++ b/lib/fastly_nsq/testing.rb
@@ -284,8 +284,7 @@ module FastlyNsq
 
     def connect(*args)
       return super(*args) unless FastlyNsq::Testing.enabled?
-      @connected = true
-      FakeConnection.new
+      @connected = FakeConnection.new
     end
 
     def empty?

--- a/lib/fastly_nsq/testing.rb
+++ b/lib/fastly_nsq/testing.rb
@@ -278,6 +278,11 @@ module FastlyNsq
       @connected
     end
 
+    def connect(*args)
+      return super(*args) unless FastlyNsq::Testing.enabled?
+      @connected = true
+    end
+
     def empty?
       FastlyNsq::Testing.enabled? ? messages.empty? : super
     end

--- a/lib/fastly_nsq/testing.rb
+++ b/lib/fastly_nsq/testing.rb
@@ -281,6 +281,9 @@ module FastlyNsq
     def connect(*args)
       return super(*args) unless FastlyNsq::Testing.enabled?
       @connected = true
+      Struct.new(:topic, :channel) do
+        def connected?; end
+      end.new 'fake_topic', 'fake_channel'
     end
 
     def empty?

--- a/lib/fastly_nsq/testing.rb
+++ b/lib/fastly_nsq/testing.rb
@@ -249,6 +249,10 @@ module FastlyNsq
 
   FastlyNsq::Listener.prepend(ListenerTesting)
 
+  class FakeConnection
+    def connected?; end
+  end
+
   module ConsumerTesting
     module ClassMethods
       def messages(topic = nil)
@@ -281,9 +285,7 @@ module FastlyNsq
     def connect(*args)
       return super(*args) unless FastlyNsq::Testing.enabled?
       @connected = true
-      Struct.new(:topic, :channel) do
-        def connected?; end
-      end.new 'fake_topic', 'fake_channel'
+      FakeConnection.new
     end
 
     def empty?


### PR DESCRIPTION
Reason for Change
===================
* patch out connect so that we are no logger going to pointlessly attempt
to connect to some server when we do not care to expect it to connect.

List of Changes
===============
* add connect method to Testing Consumer

Recommended Reviewers
=====================
@fastly/billing