### PR TITLE
Add support for configuring max_threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ FastlyNsq.configure do |config|
 
   config.max_attempts = 20
   config.max_req_timeout = (60 * 60 * 4 * 1_000) # 4 hours
+  config.max_threads = 10
 
   lc.listen 'posts', ->(m) { puts "posts: #{m.body}" }
   lc.listen 'blogs', ->(m) { puts "blogs: #{m.body}" }, priority: 3

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ FastlyNsq.configure do |config|
 
   config.max_attempts = 20
   config.max_req_timeout = (60 * 60 * 4 * 1_000) # 4 hours
-  config.max_threads = 10
+  config.max_processing_pool_threads = 10
 
   lc.listen 'posts', ->(m) { puts "posts: #{m.body}" }
   lc.listen 'blogs', ->(m) { puts "blogs: #{m.body}" }, priority: 3

--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -30,6 +30,10 @@ module FastlyNsq
     # @return [Integer]
     attr_writer :max_req_timeout
 
+    # Maximum number of threads for FastlyNsq::PriorityThreadPool
+    # @return [Integer]
+    attr_accessor :max_threads
+
     ##
     # Map of lifecycle events
     # @return [Hash]

--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -32,7 +32,7 @@ module FastlyNsq
 
     # Maximum number of threads for FastlyNsq::PriorityThreadPool
     # @return [Integer]
-    attr_accessor :max_threads
+    attr_writer :max_processing_pool_threads
 
     ##
     # Map of lifecycle events
@@ -113,6 +113,13 @@ module FastlyNsq
     # @see https://nsq.io/components/nsqd.html#command-line-options
     def max_req_timeout
       @max_req_timeout ||= ENV.fetch('MAX_REQ_TIMEOUT', 60 * 60 * 1_000).to_i
+    end
+
+    # Maximum number of threads for FastlyNsq::PriorityThreadPool
+    # Default setting is 5 and can be set via ENV['MAX_PROCESSING_POOL_THREADS']
+    # @return [Integer]
+    def max_processing_pool_threads
+      @max_processing_pool_threads ||= ENV.fetch('MAX_PROCESSING_POOL_THREADS', 5).to_i
     end
 
     ##

--- a/lib/fastly_nsq/feeder.rb
+++ b/lib/fastly_nsq/feeder.rb
@@ -32,7 +32,7 @@ class FastlyNsq::Feeder
   # swallow the exception.
   #
   # @param message [Nsq::Message]
-  # @see http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ThreadPoolExecutor.html#post-instance_method
+  # @see http://ruby-concurrency.github.io/concurrent-ruby/1.0.5/Concurrent/ThreadPoolExecutor.html#post-instance_method
   # @see Nsq::Connection#read_loop
   def push(message)
     FastlyNsq.manager.pool.post(priority) do

--- a/lib/fastly_nsq/manager.rb
+++ b/lib/fastly_nsq/manager.rb
@@ -18,6 +18,7 @@ class FastlyNsq::Manager
   # Create a FastlyNsq::Manager
   #
   # @param logger [Logger]
+  # @param max_threads [Integer] Maxiumum number of threads to be used by {FastlyNsq::PriorityThreadPool}
   # @param pool_options [Hash] Options forwarded to {FastlyNsq::PriorityThreadPool} constructor.
   def initialize(logger: FastlyNsq.logger, max_threads: FastlyNsq.max_processing_pool_threads, **pool_options)
     @done      = false

--- a/lib/fastly_nsq/manager.rb
+++ b/lib/fastly_nsq/manager.rb
@@ -24,7 +24,7 @@ class FastlyNsq::Manager
     @done      = false
     @logger    = logger
     @pool      = FastlyNsq::PriorityThreadPool.new(
-      { fallback_policy: :caller_runs, max_threads: DEFAULT_POOL_SIZE }.merge(pool_options),
+      { fallback_policy: :caller_runs, max_threads: FastlyNsq.max_threads || DEFAULT_POOL_SIZE }.merge(pool_options),
     )
   end
 

--- a/lib/fastly_nsq/manager.rb
+++ b/lib/fastly_nsq/manager.rb
@@ -4,7 +4,6 @@
 # Interface for tracking listeners and managing the processing pool.
 class FastlyNsq::Manager
   DEADLINE = 30
-  DEFAULT_POOL_SIZE = 5
 
   # @return [Boolean] Set true when all listeners are stopped
   attr_reader :done
@@ -20,11 +19,11 @@ class FastlyNsq::Manager
   #
   # @param logger [Logger]
   # @param pool_options [Hash] Options forwarded to {FastlyNsq::PriorityThreadPool} constructor.
-  def initialize(logger: FastlyNsq.logger, **pool_options)
+  def initialize(logger: FastlyNsq.logger, max_threads: FastlyNsq.max_processing_pool_threads, **pool_options)
     @done      = false
     @logger    = logger
     @pool      = FastlyNsq::PriorityThreadPool.new(
-      { fallback_policy: :caller_runs, max_threads: FastlyNsq.max_threads || DEFAULT_POOL_SIZE }.merge(pool_options),
+      { fallback_policy: :caller_runs, max_threads: max_threads }.merge(pool_options),
     )
   end
 

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe FastlyNsq::Manager do
 
   describe '#initialize' do
     it 'allows max_threads to be specified' do
-      max_threads = described_class::DEFAULT_POOL_SIZE * 2
+      max_threads = FastlyNsq.max_processing_pool_threads * 2
       manager = described_class.new(max_threads: max_threads)
 
       expect(manager.pool.max_threads).to eq(max_threads)
     end
 
-    it 'defaults max_threads to DEFAULT_POOL_SIZE' do
-      expect(subject.pool.max_threads).to eq(described_class::DEFAULT_POOL_SIZE)
+    it 'defaults max_threads to FastlyNsq.max_processing_pool_threads' do
+      expect(subject.pool.max_threads).to eq(FastlyNsq.max_processing_pool_threads)
     end
 
     it 'allows fallback_policy to be specified' do


### PR DESCRIPTION
Reason for Change
===================
* `MAX_THREADS` is a constant and not easily configured. This allows applications to set the max number of threads for the thread pool easily.

Recommended Reviewers
=====================
@fastly/billing