### PR TITLE
Log the internal NSQ id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'bundler-audit', '~> 0.5.0'
+gem 'bundler-audit'
 gem 'newrelic_rpm', require: false
 gem 'overcommit', '~> 0.32.0'
 gem 'rake', '~> 11.1.2'

--- a/fastly_nsq.gemspec
+++ b/fastly_nsq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_development_dependency 'awesome_print', '~> 1.6'
-  gem.add_development_dependency 'bundler', '~> 1.12'
+  gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'dotenv'
   gem.add_development_dependency 'pry-byebug', '~> 3.3'
   gem.add_development_dependency 'rspec', '~> 3.4'

--- a/lib/fastly_nsq/listener.rb
+++ b/lib/fastly_nsq/listener.rb
@@ -116,8 +116,9 @@ class FastlyNsq::Listener
     msg_info = {
       channel:  channel,
       topic:    topic,
-      attempts: nsq_message.attempts,
+      attempts: message.attempts,
       id:       Digest::MD5.hexdigest(nsq_message.body.to_s),
+      nsq_id:   message.id,
       metadata: message.meta,
     }
 

--- a/lib/fastly_nsq/message.rb
+++ b/lib/fastly_nsq/message.rb
@@ -20,7 +20,11 @@ class FastlyNsq::Message
   #   Delegated to +self.nsq_message+
   #   @return [Nsq::Message#timestamp]
   #   @see https://www.rubydoc.info/gems/nsq-ruby/Nsq/Message#timestamp-instance_method
-  def_delegators :@nsq_message, :attempts, :touch, :timestamp
+  # @!method id
+  #   Delegated to +self.nsq_message+
+  #   @return [Nsq::Message#id]
+  #   @see https://www.rubydoc.info/gems/nsq-ruby/Nsq/Message#id-instance_method
+  def_delegators :@nsq_message, :attempts, :touch, :timestamp, :id
 
   # @return [Symbol] Message state. Returns +nil+ if message has not been requeued or finished.
   attr_reader :managed

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'json'
 
 RSpec.describe FastlyNsq::Message do
-  let(:nsq_message) { double 'Nsq::Message', body: json_body, attempts: 1, finish: nil, requeue: nil, touch: nil, timestamp: nil }
+  let(:nsq_message) { double 'Nsq::Message', body: json_body, attempts: 1, finish: nil, requeue: nil, touch: nil, timestamp: nil, id: nil }
   let(:body)        { { 'data' => 'goes here', 'other_field' => 'is over here', 'meta' => 'meta stuff' } }
   let(:json_body)   { body.to_json }
   subject           { FastlyNsq::Message.new nsq_message }
@@ -30,7 +30,7 @@ RSpec.describe FastlyNsq::Message do
   end
 
   it 'delegates methods to the nsq_message object' do
-    %w[attempts finish requeue touch timestamp].each do |method|
+    %w[attempts finish requeue touch timestamp id].each do |method|
       subject = FastlyNsq::Message.new nsq_message
       expect(nsq_message).to receive(method)
 


### PR DESCRIPTION
Reason for Change
===================

WHen dealing with `E_FIN_FAILED` it may be useful to see when the oringal message was recieved.

List of Changes
===============
* delegate is to nsq_message
* log the id as nsq id