### PR TITLE
remove version pin on rake for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.3.5
   - 2.4.2
   - 2.5.1
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 gem 'bundler-audit'
 gem 'newrelic_rpm', require: false
 gem 'overcommit', '~> 0.32.0'
-gem 'rake', '~> 11.1.2'
+gem 'rake'
 gem 'rdoc', '~> 4.2.2'
 gem 'rubocop', '~> 0.51.0'
 gem 'rubygems-tasks', '~> 0.2'

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem 'bundler-audit'
 gem 'newrelic_rpm', require: false
 gem 'overcommit', '~> 0.32.0'
 gem 'rake'
-gem 'rdoc', '~> 4.2.2'
+gem 'rdoc'
 gem 'rubocop', '~> 0.51.0'
 gem 'rubygems-tasks', '~> 0.2'


### PR DESCRIPTION
No need for rake to be pinned and will stop dependabot from alerting.
