### PR TITLE
Update priority queue to be a :min queue by default and add setting

### DIFF
--- a/lib/fastly_nsq.rb
+++ b/lib/fastly_nsq.rb
@@ -123,6 +123,23 @@ module FastlyNsq
     end
 
     ##
+    # The type of priority queue to use. Valid values are :min and :max.
+    # The default is :min
+    # @return [Symbol]
+    def priority_queue_type
+      @priority_queue_type ||= :min
+    end
+  
+    # Set the type of priority queue to use. Valid values are :min and :max.
+    # @return [Symbol]
+    def priority_queue_type=(type)
+      raise ArgumentError, "Invalid priority queue type #{type}" unless %i[min max].include?(type.to_sym)
+
+      @priority_queue_type = type.to_sym
+    end
+
+
+    ##
     # Return an array of NSQ lookupd http addresses sourced from ENV['NSQLOOKUPD_HTTP_ADDRESS']
     # @return [Array<String>] list of nsqlookupd http addresses
     def lookupd_http_addresses

--- a/lib/fastly_nsq/priority_thread_pool.rb
+++ b/lib/fastly_nsq/priority_thread_pool.rb
@@ -6,7 +6,7 @@ class FastlyNsq::PriorityThreadPool < Concurrent::ThreadPoolExecutor
   def initialize(*)
     super
 
-    @queue = FastlyNsq::PriorityQueue.new(:max)
+    @queue = FastlyNsq::PriorityQueue.new(FastlyNsq.priority_queue_type)
   end
 
   # tries to enqueue task

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FastlyNsq
-  VERSION = '1.16.0'
+  VERSION = '2.0.0'
 end

--- a/spec/fastly_nsq_spec.rb
+++ b/spec/fastly_nsq_spec.rb
@@ -115,4 +115,28 @@ RSpec.describe FastlyNsq do
       expect { FastlyNsq.on(:foo, &-> {}) }.to raise_error(ArgumentError, /Invalid event name/)
     end
   end
+
+  describe '#priority_queue_type' do
+    it 'returns the default setting' do
+      expect(subject.priority_queue_type).to eq(:min)
+    end
+
+    it 'returns the current setting' do
+      subject.instance_variable_set(:@priority_queue_type, :max)
+
+      expect(subject.priority_queue_type).to eq(:max)
+    end
+  end
+
+  describe '#priority_queue_type=' do
+    it 'sets the priority_queue_type' do
+      subject.priority_queue_type = :max
+
+      expect(subject.priority_queue_type).to eq(:max)
+    end
+
+    it 'rasies an error if the priority_queue_type is not valid' do
+      expect { subject.priority_queue_type = :fsly }.to raise_error(ArgumentError, /Invalid priority queue type/)
+    end
+  end
 end


### PR DESCRIPTION
Summary
=======

Adds a new setting priority_queue_type that can be `:min` or `:max`. Update the default to be :min.

This is a breaking change for workflows that depend on a `:max` priority queue.


Recommended Reviewers
=====================
@fastly/billing