### PR TITLE
Support for arbitary sent_at Time

### DIFF
--- a/lib/fastly_nsq/messenger.rb
+++ b/lib/fastly_nsq/messenger.rb
@@ -129,10 +129,10 @@ module FastlyNsq::Messenger
     meta[:originating_service] = originating_service || self.originating_service
 
     meta[:sent_at] = if sent_at && sent_at.respond_to?(:iso8601)
-      sent_at.iso8601(5)
-    else
-      Time.now.iso8601(5)
-    end
+                       sent_at.iso8601(5)
+                     else
+                       Time.now.iso8601(5)
+                     end
 
     meta
   end

--- a/lib/fastly_nsq/version.rb
+++ b/lib/fastly_nsq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FastlyNsq
-  VERSION = '1.16.0'
+  VERSION = '1.17.0'
 end

--- a/spec/messenger_spec.rb
+++ b/spec/messenger_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe FastlyNsq::Messenger do
 
       expect(producer).to have_received(:write).with(expected_attributes.to_json)
     end
+
+    it 'can set the sent_at in the metadata' do
+      sent_at = Time.parse('2020-06-08 23:42:42')
+      meta = {}
+
+      expected_attributes = { data: message, meta: meta.merge(originating_service: origin, sent_at: sent_at.iso8601(5)) }
+
+      subject.producers['topic'] = producer
+
+      subject.deliver message: message, topic: 'topic', sent_at: sent_at, meta: meta, originating_service: origin
+
+      expect(producer).to have_received(:write).with(expected_attributes.to_json)
+    end
   end
 
   describe '#deliver_multi' do


### PR DESCRIPTION
Reason for Change
===================

Being able to set the `sent_at` time is useful when streaming large sets of messages where using `mpub` might be impractical but you still want the sent_at to be the same.

List of Changes
===============
* add `sent_at` param to deliver and deliver_multi methods

Risks
=====
* Low. Default behavior remains the same.

Recommended Reviewers
=====================
@fastly/billing